### PR TITLE
Add discovery-first link analyzer foundation

### DIFF
--- a/app/src/main/java/com/localdownloader/data/DownloadRepositoryImpl.kt
+++ b/app/src/main/java/com/localdownloader/data/DownloadRepositoryImpl.kt
@@ -16,6 +16,8 @@ import com.localdownloader.domain.models.ConversionRequest
 import com.localdownloader.domain.models.DownloadOptions
 import com.localdownloader.domain.models.DownloadStatus
 import com.localdownloader.domain.models.DownloadTask
+import com.localdownloader.domain.models.FormatLoadResult
+import com.localdownloader.domain.models.LinkAnalysisResult
 import com.localdownloader.domain.models.MediaSyncResult
 import com.localdownloader.domain.models.PlaylistDownloadRequest
 import com.localdownloader.domain.models.VideoInfo
@@ -94,6 +96,28 @@ class DownloadRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun analyzeLink(
+        url: String,
+        cookiesPath: String?,
+        userAgent: String?,
+    ): Result<LinkAnalysisResult> {
+        logger.i("DownloadRepository", "analyzeLink called for: $url")
+        val result = formatExtractor.analyzeLink(
+            url = url,
+            cookiesPath = cookiesPath,
+            userAgent = userAgent,
+        )
+        result.onSuccess { info ->
+            logger.i(
+                "DownloadRepository",
+                "analyzeLink success: title='${info.title}', itemCount=${info.items.size}, source=${info.sourceKind}",
+            )
+        }.onFailure { error ->
+            logger.e("DownloadRepository", "analyzeLink failed for: $url", error)
+        }
+        return result
+    }
+
     override suspend fun analyzeUrl(
         url: String,
         cookiesPath: String?,
@@ -114,6 +138,57 @@ class DownloadRepositoryImpl @Inject constructor(
             logger.e("DownloadRepository", "analyzeUrl failed for: $url", error)
         }
         return result
+    }
+
+    override suspend fun loadFormats(
+        url: String,
+        cookiesPath: String?,
+        userAgent: String?,
+    ): Result<FormatLoadResult> {
+        logger.i("DownloadRepository", "loadFormats called for: $url")
+        val result = formatExtractor.loadFormats(
+            url = url,
+            cookiesPath = cookiesPath,
+            userAgent = userAgent,
+        )
+        result.onSuccess { info ->
+            logger.i(
+                "DownloadRepository",
+                "loadFormats success: title='${info.title}', formats=${info.formats.size}",
+            )
+        }.onFailure { error ->
+            logger.e("DownloadRepository", "loadFormats failed for: $url", error)
+        }
+        return result
+    }
+
+    override suspend fun loadFormatsForItems(
+        urls: List<String>,
+        cookiesPath: String?,
+        userAgent: String?,
+    ): Result<List<FormatLoadResult>> {
+        return runCatching {
+            val successes = mutableListOf<FormatLoadResult>()
+            var firstFailure: Throwable? = null
+            urls.forEach { url ->
+                formatExtractor.loadFormats(
+                    url = url,
+                    cookiesPath = cookiesPath,
+                    userAgent = userAgent,
+                ).onSuccess { result ->
+                    successes += result
+                }.onFailure { error ->
+                    logger.w("DownloadRepository", "loadFormatsForItems item failed for: $url", error)
+                    if (firstFailure == null) {
+                        firstFailure = error
+                    }
+                }
+            }
+            if (successes.isEmpty() && firstFailure != null) {
+                throw firstFailure ?: IllegalStateException("Unable to load formats for the requested items.")
+            }
+            successes
+        }
     }
 
     override suspend fun enqueueDownload(options: DownloadOptions, titleHint: String): Result<String> {

--- a/app/src/main/java/com/localdownloader/domain/models/FormatLoadRequest.kt
+++ b/app/src/main/java/com/localdownloader/domain/models/FormatLoadRequest.kt
@@ -1,0 +1,8 @@
+package com.localdownloader.domain.models
+
+/**
+ * Request model for loading formats for one or more discovered items.
+ */
+data class FormatLoadRequest(
+    val webpageUrls: List<String>,
+)

--- a/app/src/main/java/com/localdownloader/domain/models/FormatLoadResult.kt
+++ b/app/src/main/java/com/localdownloader/domain/models/FormatLoadResult.kt
@@ -1,0 +1,12 @@
+package com.localdownloader.domain.models
+
+/**
+ * Typed format loading result for one URL.
+ */
+data class FormatLoadResult(
+    val webpageUrl: String,
+    val title: String,
+    val formats: List<MediaFormat>,
+    val extractorArgs: String? = null,
+    val infoJsonPath: String? = null,
+)

--- a/app/src/main/java/com/localdownloader/domain/models/FormatViewMode.kt
+++ b/app/src/main/java/com/localdownloader/domain/models/FormatViewMode.kt
@@ -1,0 +1,11 @@
+package com.localdownloader.domain.models
+
+/**
+ * Presentation mode for the format browser.
+ */
+enum class FormatViewMode {
+    ALL,
+    SUGGESTED,
+    SMALLEST,
+    GENERIC,
+}

--- a/app/src/main/java/com/localdownloader/domain/models/LinkAnalysisItem.kt
+++ b/app/src/main/java/com/localdownloader/domain/models/LinkAnalysisItem.kt
@@ -1,0 +1,17 @@
+package com.localdownloader.domain.models
+
+/**
+ * Lightweight metadata for one discovered downloadable item.
+ */
+data class LinkAnalysisItem(
+    val id: String,
+    val title: String,
+    val webpageUrl: String,
+    val uploader: String? = null,
+    val durationSeconds: Long? = null,
+    val thumbnailUrl: String? = null,
+    val playlistItemIndex: Int? = null,
+    val formats: List<MediaFormat> = emptyList(),
+    val extractorArgs: String? = null,
+    val infoJsonPath: String? = null,
+)

--- a/app/src/main/java/com/localdownloader/domain/models/LinkAnalysisResult.kt
+++ b/app/src/main/java/com/localdownloader/domain/models/LinkAnalysisResult.kt
@@ -1,0 +1,26 @@
+package com.localdownloader.domain.models
+
+/**
+ * Root discovery result used by the new link analyzer flow.
+ */
+data class LinkAnalysisResult(
+    val sourceKind: LinkSourceKind,
+    val input: String,
+    val rootId: String,
+    val title: String,
+    val uploader: String? = null,
+    val durationSeconds: Long? = null,
+    val thumbnailUrl: String? = null,
+    val webpageUrl: String? = null,
+    val rootFormats: List<MediaFormat> = emptyList(),
+    val extractorArgs: String? = null,
+    val infoJsonPath: String? = null,
+    val playlistCount: Int? = null,
+    val items: List<LinkAnalysisItem> = emptyList(),
+) {
+    val isCollection: Boolean
+        get() = sourceKind == LinkSourceKind.PLAYLIST || sourceKind == LinkSourceKind.CHANNEL
+
+    val primaryItem: LinkAnalysisItem?
+        get() = items.firstOrNull()
+}

--- a/app/src/main/java/com/localdownloader/domain/models/LinkSourceKind.kt
+++ b/app/src/main/java/com/localdownloader/domain/models/LinkSourceKind.kt
@@ -1,0 +1,11 @@
+package com.localdownloader.domain.models
+
+/**
+ * High-level source classification for discovery-first link analysis.
+ */
+enum class LinkSourceKind {
+    SINGLE_VIDEO,
+    PLAYLIST,
+    CHANNEL,
+    GENERIC_URL,
+}

--- a/app/src/main/java/com/localdownloader/domain/repositories/DownloaderRepository.kt
+++ b/app/src/main/java/com/localdownloader/domain/repositories/DownloaderRepository.kt
@@ -5,6 +5,8 @@ import com.localdownloader.domain.models.CompressionRequest
 import com.localdownloader.domain.models.ConversionRequest
 import com.localdownloader.domain.models.DownloadOptions
 import com.localdownloader.domain.models.DownloadTask
+import com.localdownloader.domain.models.FormatLoadResult
+import com.localdownloader.domain.models.LinkAnalysisResult
 import com.localdownloader.domain.models.MediaSyncResult
 import com.localdownloader.domain.models.PlaylistDownloadRequest
 import com.localdownloader.domain.models.VideoInfo
@@ -14,11 +16,26 @@ import kotlinx.coroutines.flow.Flow
  * Domain-level contract for all downloader and media-processing operations.
  */
 interface DownloaderRepository {
+    suspend fun analyzeLink(
+        url: String,
+        cookiesPath: String? = null,
+        userAgent: String? = null,
+    ): Result<LinkAnalysisResult>
     suspend fun analyzeUrl(
         url: String,
         cookiesPath: String? = null,
         userAgent: String? = null,
     ): Result<VideoInfo>
+    suspend fun loadFormats(
+        url: String,
+        cookiesPath: String? = null,
+        userAgent: String? = null,
+    ): Result<FormatLoadResult>
+    suspend fun loadFormatsForItems(
+        urls: List<String>,
+        cookiesPath: String? = null,
+        userAgent: String? = null,
+    ): Result<List<FormatLoadResult>>
     suspend fun enqueueDownload(options: DownloadOptions, titleHint: String): Result<String>
     suspend fun enqueuePlaylistDownload(
         playlistTitle: String,

--- a/app/src/main/java/com/localdownloader/downloader/FormatExtractor.kt
+++ b/app/src/main/java/com/localdownloader/downloader/FormatExtractor.kt
@@ -71,28 +71,11 @@ class FormatExtractor @Inject constructor(
     ): Result<LinkAnalysisResult> {
         return runCatching {
             logger.i("FormatExtractor", "Starting discovery-first link analysis for URL: $url")
-            val sourceKind = LinkSourceClassifier.classify(url)
-            val resolved = resolveBestAnalyzeCandidate(
+            fastAnalyzeLink(
                 url = url,
                 cookiesPath = cookiesPath,
                 userAgent = userAgent,
-                purpose = AnalyzePurpose.DISCOVERY,
             )
-            mapLinkAnalysis(
-                root = resolved.root,
-                fallbackUrl = url,
-                extractorArgs = resolved.extractorArgs,
-                infoJsonPath = resolved.infoJsonPath,
-            ).let { analysis ->
-                if (sourceKind == LinkSourceKind.SINGLE_VIDEO) {
-                    analysis.copy(
-                        rootFormats = emptyList(),
-                        items = analysis.items.map { item -> item.copy(formats = emptyList(), infoJsonPath = null) },
-                    )
-                } else {
-                    analysis
-                }
-            }
         }.onFailure { error ->
             logger.e("FormatExtractor", "Link analysis exception for URL: $url", error)
         }
@@ -217,6 +200,148 @@ class FormatExtractor @Inject constructor(
         }
 
         return best ?: throw IllegalStateException(lastFailureMessage ?: "yt-dlp analyze failed")
+    }
+
+    private suspend fun fastAnalyzeLink(
+        url: String,
+        cookiesPath: String?,
+        userAgent: String?,
+    ): LinkAnalysisResult {
+        val hasCookies = !cookiesPath.isNullOrBlank() && File(cookiesPath).exists()
+        val candidates = if (isYoutubeUrl(url)) {
+            YoutubeRequestPlanner.discoveryCandidates(cookiesAvailable = hasCookies)
+                .take(1)
+        } else {
+            listOf<String?>(null)
+        }
+
+        var lastFailure: String? = null
+        candidates.forEachIndexed { index, extractorArgs ->
+            val attempt = runCatching {
+                executeFastDiscoveryRequest(
+                    url = url,
+                    extractorArgs = extractorArgs,
+                    cookiesPath = cookiesPath,
+                    userAgent = userAgent,
+                )
+            }.getOrElse { error ->
+                logger.w(
+                    "FormatExtractor",
+                    "Fast discovery candidate[$index] failed for args=${extractorArgs ?: "(default)"}",
+                    error,
+                )
+                Result.failure(
+                    IllegalStateException(
+                        error.message?.takeIf { it.isNotBlank() } ?: "Fast discovery failed",
+                        error,
+                    ),
+                )
+            }
+
+            val analysis = attempt.getOrNull()
+            if (analysis != null) {
+                logger.i(
+                    "FormatExtractor",
+                    "Fast discovery success args=${extractorArgs ?: "(default)"} source=${analysis.sourceKind} items=${analysis.items.size}",
+                )
+                return analysis
+            }
+            lastFailure = attempt.exceptionOrNull()?.message
+        }
+
+        if (!lastFailure.isNullOrBlank() && isTransientAnalyzeFailure(lastFailure)) {
+            throw IllegalStateException(lastFailure)
+        }
+
+        logger.i("FormatExtractor", "Fast discovery fell back to full analyzer for URL: $url")
+        val resolved = resolveBestAnalyzeCandidate(
+            url = url,
+            cookiesPath = cookiesPath,
+            userAgent = userAgent,
+            purpose = AnalyzePurpose.DISCOVERY,
+        )
+        val sourceKind = LinkSourceClassifier.classify(url)
+        val analysis = mapLinkAnalysis(
+            root = resolved.root,
+            fallbackUrl = url,
+            extractorArgs = resolved.extractorArgs,
+            infoJsonPath = resolved.infoJsonPath,
+        )
+        return if (sourceKind == LinkSourceKind.SINGLE_VIDEO) {
+            analysis.copy(
+                rootFormats = emptyList(),
+                items = analysis.items.map { item -> item.copy(formats = emptyList(), infoJsonPath = null) },
+            )
+        } else {
+            analysis
+        }
+    }
+
+    private suspend fun executeFastDiscoveryRequest(
+        url: String,
+        extractorArgs: String?,
+        cookiesPath: String?,
+        userAgent: String?,
+    ): Result<LinkAnalysisResult> {
+        val stdoutLines = mutableListOf<String>()
+        val stderrLines = mutableListOf<String>()
+        val args = buildFastDiscoveryArgs(
+            url = url,
+            extractorArgs = extractorArgs,
+            cookiesPath = cookiesPath,
+            userAgent = userAgent,
+        )
+        val result = ytDlpExecutor.execute(
+            args = args,
+            logOutputLines = false,
+            onStdoutLine = { line ->
+                val trimmed = line.trim()
+                if (trimmed.isNotBlank()) {
+                    stdoutLines += trimmed
+                }
+            },
+            onStderrLine = { line ->
+                val trimmed = line.trim()
+                if (trimmed.isNotBlank()) {
+                    stderrLines += trimmed
+                }
+            },
+            timeoutMs = FAST_DISCOVERY_PROCESS_TIMEOUT_MILLIS,
+        )
+
+        val combinedStdout = buildString {
+            if (stdoutLines.isNotEmpty()) {
+                append(stdoutLines.joinToString(System.lineSeparator()))
+            } else if (result.stdout.isNotBlank()) {
+                append(result.stdout.trim())
+            }
+        }.trim()
+
+        val lineAnalysis = parseFastDiscoveryOutput(
+            url = url,
+            extractorArgs = extractorArgs,
+            stdoutLines = stdoutLines,
+            combinedStdout = combinedStdout,
+        )
+        if (lineAnalysis != null) {
+            return Result.success(lineAnalysis)
+        }
+
+        if (!result.isSuccess) {
+            val message = extractAnalyzeFailureMessage(
+                stderr = stderrLines.joinToString(System.lineSeparator()).ifBlank { result.stderr },
+                stdout = combinedStdout.ifBlank { result.stdout },
+            )
+            return Result.failure(IllegalStateException(sanitizeAnalyzeFailureMessage(message)))
+        }
+
+        return Result.failure(
+            IllegalStateException(
+                stderrLines.lastOrNull()
+                    ?: preferredAnalyzeFailureLine(result.stderr)
+                    ?: "Fast discovery returned no usable metadata",
+            ),
+        )
     }
 
     private suspend fun analyzeWithExtractorForDiscovery(
@@ -380,6 +505,162 @@ class FormatExtractor @Inject constructor(
             ?.let(::parseFormats)
             .orEmpty()
         return rootFormats.ifEmpty { fallbackFormats }
+    }
+
+    private fun parseFastDiscoveryOutput(
+        url: String,
+        extractorArgs: String?,
+        stdoutLines: List<String>,
+        combinedStdout: String,
+    ): LinkAnalysisResult? {
+        if (stdoutLines.isNotEmpty()) {
+            parseDiscoveryLineItems(
+                lines = stdoutLines,
+                fallbackUrl = url,
+                extractorArgs = extractorArgs,
+            )?.let { return it }
+        }
+
+        val normalizedStdout = combinedStdout.trim()
+        if (normalizedStdout.isBlank()) return null
+
+        return runCatching {
+            val root = json.parseToJsonElement(normalizedStdout).jsonObject
+            val mapped = mapLinkAnalysis(
+                root = root,
+                fallbackUrl = url,
+                extractorArgs = extractorArgs,
+                infoJsonPath = null,
+            )
+            if (mapped.sourceKind == LinkSourceKind.SINGLE_VIDEO) {
+                mapped.copy(
+                    rootFormats = emptyList(),
+                    items = mapped.items.map { item -> item.copy(formats = emptyList(), infoJsonPath = null) },
+                )
+            } else {
+                mapped
+            }
+        }.getOrNull()
+    }
+
+    private fun parseDiscoveryLineItems(
+        lines: List<String>,
+        fallbackUrl: String,
+        extractorArgs: String?,
+    ): LinkAnalysisResult? {
+        val parsedObjects = lines.mapNotNull { line ->
+            runCatching { json.parseToJsonElement(line).jsonObject }.getOrNull()
+        }
+        if (parsedObjects.isEmpty()) return null
+
+        val sourceKindHint = LinkSourceClassifier.classify(fallbackUrl)
+        val rootObject = parsedObjects.firstOrNull { candidate ->
+            val type = candidate["_type"]?.jsonPrimitive?.contentOrNull
+            type == "playlist" || candidate["entries"] is JsonArray
+        }
+        if (rootObject != null) {
+            val mapped = mapLinkAnalysis(
+                root = rootObject,
+                fallbackUrl = fallbackUrl,
+                extractorArgs = extractorArgs,
+                infoJsonPath = null,
+            )
+            return if (mapped.sourceKind == LinkSourceKind.SINGLE_VIDEO) {
+                mapped.copy(
+                    rootFormats = emptyList(),
+                    items = mapped.items.map { item -> item.copy(formats = emptyList(), infoJsonPath = null) },
+                )
+            } else {
+                mapped
+            }
+        }
+
+        data class DiscoverySummary(
+            val title: String? = null,
+            val uploader: String? = null,
+            val webpageUrl: String? = null,
+            val playlistCount: Int? = null,
+        )
+
+        var summary = DiscoverySummary()
+        val items = parsedObjects.mapIndexedNotNull { index, item ->
+            val id = item["id"]?.jsonPrimitive?.contentOrNull.orEmpty()
+            val title = item["title"]?.jsonPrimitive?.contentOrNull.orEmpty()
+            if (title == "[Private video]" || title == "[Deleted video]") {
+                return@mapIndexedNotNull null
+            }
+            val rawWebpageUrl = item["webpage_url"]?.jsonPrimitive?.contentOrNull
+                ?: item["original_url"]?.jsonPrimitive?.contentOrNull
+                ?: item["url"]?.jsonPrimitive?.contentOrNull
+            val resolvedUrl = resolvePlaylistEntryWebpageUrl(
+                rawUrl = rawWebpageUrl,
+                entryId = id,
+                playlistSourceUrl = fallbackUrl,
+            ) ?: if (sourceKindHint == LinkSourceKind.SINGLE_VIDEO) fallbackUrl else null
+            if (resolvedUrl == null) return@mapIndexedNotNull null
+
+            if (summary.title.isNullOrBlank()) {
+                summary = summary.copy(
+                    title = item["playlist_title"]?.jsonPrimitive?.contentOrNull
+                        ?: item["channel"]?.jsonPrimitive?.contentOrNull
+                        ?: title.takeIf { sourceKindHint == LinkSourceKind.SINGLE_VIDEO },
+                    uploader = item["playlist_uploader"]?.jsonPrimitive?.contentOrNull
+                        ?: item["uploader"]?.jsonPrimitive?.contentOrNull,
+                    webpageUrl = item["playlist_webpage_url"]?.jsonPrimitive?.contentOrNull
+                        ?: fallbackUrl,
+                    playlistCount = item["playlist_count"]?.jsonPrimitive?.intOrNull,
+                )
+            }
+
+            LinkAnalysisItem(
+                id = id.ifBlank { "item-${index + 1}" },
+                title = title.ifBlank { "Item ${index + 1}" },
+                webpageUrl = resolvedUrl,
+                uploader = item["uploader"]?.jsonPrimitive?.contentOrNull
+                    ?: item["channel"]?.jsonPrimitive?.contentOrNull,
+                durationSeconds = item["duration"]?.jsonPrimitive?.longOrNull,
+                thumbnailUrl = resolveThumbnailUrl(item),
+                playlistItemIndex = item["playlist_index"]?.jsonPrimitive?.intOrNull ?: index + 1,
+                formats = emptyList(),
+                extractorArgs = extractorArgs,
+                infoJsonPath = null,
+            )
+        }
+
+        if (items.isEmpty()) return null
+
+        val sourceKind = if (items.size > 1 || sourceKindHint == LinkSourceKind.PLAYLIST || sourceKindHint == LinkSourceKind.CHANNEL) {
+            if (sourceKindHint == LinkSourceKind.CHANNEL) LinkSourceKind.CHANNEL else LinkSourceKind.PLAYLIST
+        } else {
+            LinkSourceKind.SINGLE_VIDEO
+        }
+        val primaryItem = items.first()
+        return LinkAnalysisResult(
+            sourceKind = sourceKind,
+            input = fallbackUrl,
+            rootId = if (sourceKind == LinkSourceKind.SINGLE_VIDEO) primaryItem.id else "",
+            title = summary.title?.takeIf { it.isNotBlank() }
+                ?: primaryItem.title,
+            uploader = summary.uploader ?: primaryItem.uploader,
+            durationSeconds = if (sourceKind == LinkSourceKind.SINGLE_VIDEO) primaryItem.durationSeconds else null,
+            thumbnailUrl = primaryItem.thumbnailUrl,
+            webpageUrl = summary.webpageUrl ?: primaryItem.webpageUrl,
+            rootFormats = emptyList(),
+            extractorArgs = extractorArgs,
+            infoJsonPath = null,
+            playlistCount = if (sourceKind == LinkSourceKind.SINGLE_VIDEO) null else summary.playlistCount ?: items.size,
+            items = items,
+        )
+    }
+
+    private fun resolveThumbnailUrl(item: JsonObject): String? {
+        item["thumbnail"]?.jsonPrimitive?.contentOrNull?.let { return it }
+        val thumbnails = item["thumbnails"] as? JsonArray ?: return null
+        return thumbnails.lastOrNull()
+            ?.jsonObject
+            ?.get("url")
+            ?.jsonPrimitive
+            ?.contentOrNull
     }
 
     private fun resolveSourceKind(
@@ -663,6 +944,55 @@ class FormatExtractor @Inject constructor(
             useLineJsonMode = useLineJsonMode,
             requestMode = requestMode,
         )
+    }
+
+    private fun buildFastDiscoveryArgs(
+        url: String,
+        extractorArgs: String?,
+        cookiesPath: String?,
+        userAgent: String?,
+    ): List<String> {
+        val tempDir = File(context.cacheDir, "tmp").apply { mkdirs() }
+        return buildList {
+            add("-j")
+            add("--skip-download")
+            add("--quiet")
+            add("--ignore-errors")
+            add("--no-warnings")
+            add("--ignore-config")
+            add("-R")
+            add("1")
+            add("--compat-options")
+            add("manifest-filesize-approx")
+            add("--socket-timeout")
+            add(DEFAULT_ANALYZE_SOCKET_TIMEOUT_SECONDS.toString())
+            add("-P")
+            add(tempDir.absolutePath)
+            if (shouldApplyFlatPlaylistDiscovery(url)) {
+                add("--flat-playlist")
+            }
+            add("--lazy-playlist")
+            if (!cookiesPath.isNullOrBlank() && File(cookiesPath).exists()) {
+                add("--cookies")
+                add(cookiesPath)
+            }
+            if (!userAgent.isNullOrBlank()) {
+                add("--add-header")
+                add("User-Agent:$userAgent")
+            }
+            if (!extractorArgs.isNullOrBlank()) {
+                add("--extractor-args")
+                add(extractorArgs)
+            }
+            add(url)
+        }
+    }
+
+    private fun shouldApplyFlatPlaylistDiscovery(url: String): Boolean {
+        val normalized = url.trim().lowercase()
+        if (normalized.isBlank()) return false
+        if (normalized.contains("soundcloud.com")) return false
+        return true
     }
 
     private fun extractAnalyzeFailureMessage(stderr: String, stdout: String): String {
@@ -1042,6 +1372,7 @@ class FormatExtractor @Inject constructor(
 
 internal const val DEFAULT_ANALYZE_SOCKET_TIMEOUT_SECONDS = 5
 internal const val EXTENDED_ANALYZE_SOCKET_TIMEOUT_SECONDS = 15
+internal const val FAST_DISCOVERY_PROCESS_TIMEOUT_MILLIS = 12_000L
 internal const val DEFAULT_ANALYZE_PROCESS_TIMEOUT_MILLIS = 20_000L
 internal const val EXTENDED_ANALYZE_PROCESS_TIMEOUT_MILLIS = 40_000L
 

--- a/app/src/main/java/com/localdownloader/downloader/FormatExtractor.kt
+++ b/app/src/main/java/com/localdownloader/downloader/FormatExtractor.kt
@@ -71,17 +71,28 @@ class FormatExtractor @Inject constructor(
     ): Result<LinkAnalysisResult> {
         return runCatching {
             logger.i("FormatExtractor", "Starting discovery-first link analysis for URL: $url")
+            val sourceKind = LinkSourceClassifier.classify(url)
             val resolved = resolveBestAnalyzeCandidate(
                 url = url,
                 cookiesPath = cookiesPath,
                 userAgent = userAgent,
+                purpose = AnalyzePurpose.DISCOVERY,
             )
             mapLinkAnalysis(
                 root = resolved.root,
                 fallbackUrl = url,
                 extractorArgs = resolved.extractorArgs,
                 infoJsonPath = resolved.infoJsonPath,
-            )
+            ).let { analysis ->
+                if (sourceKind == LinkSourceKind.SINGLE_VIDEO) {
+                    analysis.copy(
+                        rootFormats = emptyList(),
+                        items = analysis.items.map { item -> item.copy(formats = emptyList(), infoJsonPath = null) },
+                    )
+                } else {
+                    analysis
+                }
+            }
         }.onFailure { error ->
             logger.e("FormatExtractor", "Link analysis exception for URL: $url", error)
         }
@@ -120,10 +131,15 @@ class FormatExtractor @Inject constructor(
         cookiesPath: String?,
         userAgent: String?,
         requestMode: AnalyzeRequestMode = resolveAnalyzeRequestMode(url),
+        purpose: AnalyzePurpose = AnalyzePurpose.FULL,
     ): AnalyzeCandidate {
         val hasCookies = !cookiesPath.isNullOrBlank() && File(cookiesPath).exists()
         val extractorCandidates = if (isYoutubeUrl(url)) {
-            YoutubeRequestPlanner.analyzeCandidates(cookiesAvailable = hasCookies)
+            if (purpose == AnalyzePurpose.DISCOVERY) {
+                YoutubeRequestPlanner.discoveryCandidates(cookiesAvailable = hasCookies)
+            } else {
+                YoutubeRequestPlanner.analyzeCandidates(cookiesAvailable = hasCookies)
+            }
         } else {
             listOf<String?>(null)
         }
@@ -139,13 +155,23 @@ class FormatExtractor @Inject constructor(
             }
             if (best != null && !shouldTryMoreCandidates(best?.stats)) return@forEachIndexed
             val attempt = runCatching {
-                analyzeWithExtractor(
-                    url = url,
-                    extractorArgs = extractorArgs,
-                    cookiesPath = cookiesPath,
-                    userAgent = userAgent,
-                    requestMode = requestMode,
-                )
+                if (purpose == AnalyzePurpose.DISCOVERY) {
+                    analyzeWithExtractorForDiscovery(
+                        url = url,
+                        extractorArgs = extractorArgs,
+                        cookiesPath = cookiesPath,
+                        userAgent = userAgent,
+                        requestMode = requestMode,
+                    )
+                } else {
+                    analyzeWithExtractor(
+                        url = url,
+                        extractorArgs = extractorArgs,
+                        cookiesPath = cookiesPath,
+                        userAgent = userAgent,
+                        requestMode = requestMode,
+                    )
+                }
             }.getOrElse { error ->
                 logger.w(
                     "FormatExtractor",
@@ -191,6 +217,49 @@ class FormatExtractor @Inject constructor(
         }
 
         return best ?: throw IllegalStateException(lastFailureMessage ?: "yt-dlp analyze failed")
+    }
+
+    private suspend fun analyzeWithExtractorForDiscovery(
+        url: String,
+        extractorArgs: String?,
+        cookiesPath: String?,
+        userAgent: String?,
+        requestMode: AnalyzeRequestMode,
+    ): AnalyzeAttempt {
+        if (requestMode == AnalyzeRequestMode.YOUTUBE_PLAYLIST_FAST) {
+            return analyzeWithExtractor(
+                url = url,
+                extractorArgs = extractorArgs,
+                cookiesPath = cookiesPath,
+                userAgent = userAgent,
+                requestMode = requestMode,
+            )
+        }
+
+        val cachedInfoJsonPath = resolveRecentInfoJsonSnapshotPath(url)
+        val capturedInfoJsonFile = createAnalyzeCaptureFile(url = url, extractorArgs = extractorArgs)
+        val lineJsonAttempt = executeAnalyzeAttempt(
+            url = url,
+            extractorArgs = extractorArgs,
+            cookiesPath = cookiesPath,
+            userAgent = userAgent,
+            capturedInfoJsonFile = capturedInfoJsonFile,
+            loadInfoJsonPath = cachedInfoJsonPath,
+            socketTimeoutSeconds = DEFAULT_ANALYZE_SOCKET_TIMEOUT_SECONDS,
+            useLineJsonMode = true,
+            requestMode = requestMode,
+        )
+        if (lineJsonAttempt.candidate != null) {
+            return lineJsonAttempt
+        }
+
+        return analyzeWithExtractor(
+            url = url,
+            extractorArgs = extractorArgs,
+            cookiesPath = cookiesPath,
+            userAgent = userAgent,
+            requestMode = requestMode,
+        )
     }
 
     private fun logFormatSummary(url: String, formats: List<MediaFormat>, extractorArgs: String?) {
@@ -1072,6 +1141,11 @@ internal fun buildAnalyzeArgsForRequest(
 internal enum class AnalyzeRequestMode {
     STANDARD,
     YOUTUBE_PLAYLIST_FAST,
+}
+
+private enum class AnalyzePurpose {
+    FULL,
+    DISCOVERY,
 }
 
 internal fun looksLikeYoutubeUrl(url: String): Boolean {

--- a/app/src/main/java/com/localdownloader/downloader/FormatExtractor.kt
+++ b/app/src/main/java/com/localdownloader/downloader/FormatExtractor.kt
@@ -1,6 +1,10 @@
 package com.localdownloader.downloader
 
 import android.content.Context
+import com.localdownloader.domain.models.FormatLoadResult
+import com.localdownloader.domain.models.LinkAnalysisItem
+import com.localdownloader.domain.models.LinkAnalysisResult
+import com.localdownloader.domain.models.LinkSourceKind
 import com.localdownloader.domain.models.MediaFormat
 import com.localdownloader.domain.models.PlaylistEntry
 import com.localdownloader.domain.models.VideoInfo
@@ -38,78 +42,11 @@ class FormatExtractor @Inject constructor(
     ): Result<VideoInfo> {
         return runCatching {
             logger.i("FormatExtractor", "Starting yt-dlp analyze for URL: $url")
-            val analyzeMode = resolveAnalyzeRequestMode(url)
-
-            val hasCookies = !cookiesPath.isNullOrBlank() && File(cookiesPath).exists()
-            val extractorCandidates = if (isYoutubeUrl(url)) {
-                YoutubeRequestPlanner.analyzeCandidates(cookiesAvailable = hasCookies)
-            } else {
-                listOf<String?>(null)
-            }
-
-            var best: AnalyzeCandidate? = null
-            var lastFailureMessage: String? = null
-            extractorCandidates.forEachIndexed { index, extractorArgs ->
-                if (analyzeMode == AnalyzeRequestMode.YOUTUBE_PLAYLIST_FAST &&
-                    best?.isPlaylistResult == true &&
-                    (best?.playlistEntryCount ?: 0) > 0
-                ) {
-                    return@forEachIndexed
-                }
-                if (best != null && !shouldTryMoreCandidates(best?.stats)) return@forEachIndexed
-                val attempt = runCatching {
-                    analyzeWithExtractor(
-                        url = url,
-                        extractorArgs = extractorArgs,
-                        cookiesPath = cookiesPath,
-                        userAgent = userAgent,
-                        requestMode = analyzeMode,
-                    )
-                }.getOrElse { error ->
-                    logger.w(
-                        "FormatExtractor",
-                        "Analyze candidate[$index] crashed for args=${extractorArgs ?: "(default)"}",
-                        error,
-                    )
-                    AnalyzeAttempt(
-                        candidate = null,
-                        errorMessage = sanitizeAnalyzeFailureMessage(
-                            error.message?.takeIf { it.isNotBlank() } ?: "yt-dlp analyze failed",
-                        ),
-                    )
-                }
-                val candidate = attempt.candidate
-                if (candidate != null) {
-                    val stats = candidate.stats
-                    val descriptor = extractorArgs ?: "(default)"
-                    if (analyzeMode == AnalyzeRequestMode.YOUTUBE_PLAYLIST_FAST) {
-                        logger.i(
-                            "FormatExtractor",
-                            "Analyze candidate[$index] args=$descriptor playlistEntries=${candidate.playlistEntryCount} playlist=${candidate.isPlaylistResult}",
-                        )
-                    } else {
-                        logger.i(
-                            "FormatExtractor",
-                            "Analyze candidate[$index] args=$descriptor formats=${stats.total} videoOnly=${stats.videoOnly} audioOnly=${stats.audioOnly} maxHeight=${stats.maxHeight}",
-                        )
-                    }
-                    if (analyzeMode == AnalyzeRequestMode.YOUTUBE_PLAYLIST_FAST) {
-                        if (best == null || candidate.playlistEntryCount > (best?.playlistEntryCount ?: -1)) {
-                            best = candidate
-                        }
-                        if (candidate.isPlaylistResult && candidate.playlistEntryCount > 0) return@forEachIndexed
-                        return@forEachIndexed
-                    }
-                    if (best == null || stats.isBetterThan(best?.stats)) {
-                        best = candidate
-                    }
-                    if (stats.hasAdaptiveVideo) return@forEachIndexed
-                } else if (!attempt.errorMessage.isNullOrBlank()) {
-                    lastFailureMessage = attempt.errorMessage
-                }
-            }
-
-            val resolved = best ?: throw IllegalStateException(lastFailureMessage ?: "yt-dlp analyze failed")
+            val resolved = resolveBestAnalyzeCandidate(
+                url = url,
+                cookiesPath = cookiesPath,
+                userAgent = userAgent,
+            )
             mapVideoInfo(
                 root = resolved.root,
                 fallbackUrl = url,
@@ -125,6 +62,135 @@ class FormatExtractor @Inject constructor(
         }.onFailure { error ->
             logger.e("FormatExtractor", "Analyze exception for URL: $url", error)
         }
+    }
+
+    suspend fun analyzeLink(
+        url: String,
+        cookiesPath: String? = null,
+        userAgent: String? = null,
+    ): Result<LinkAnalysisResult> {
+        return runCatching {
+            logger.i("FormatExtractor", "Starting discovery-first link analysis for URL: $url")
+            val resolved = resolveBestAnalyzeCandidate(
+                url = url,
+                cookiesPath = cookiesPath,
+                userAgent = userAgent,
+            )
+            mapLinkAnalysis(
+                root = resolved.root,
+                fallbackUrl = url,
+                extractorArgs = resolved.extractorArgs,
+                infoJsonPath = resolved.infoJsonPath,
+            )
+        }.onFailure { error ->
+            logger.e("FormatExtractor", "Link analysis exception for URL: $url", error)
+        }
+    }
+
+    suspend fun loadFormats(
+        url: String,
+        cookiesPath: String? = null,
+        userAgent: String? = null,
+    ): Result<FormatLoadResult> {
+        return runCatching {
+            logger.i("FormatExtractor", "Starting format load for URL: $url")
+            val resolved = resolveBestAnalyzeCandidate(
+                url = url,
+                cookiesPath = cookiesPath,
+                userAgent = userAgent,
+                requestMode = AnalyzeRequestMode.STANDARD,
+            )
+            val title = resolved.root["title"]?.jsonPrimitive?.contentOrNull ?: "Untitled"
+            val formats = extractFormats(resolved.root)
+            logFormatSummary(url = url, formats = formats, extractorArgs = resolved.extractorArgs)
+            FormatLoadResult(
+                webpageUrl = resolved.root["webpage_url"]?.jsonPrimitive?.contentOrNull ?: url,
+                title = title,
+                formats = formats,
+                extractorArgs = resolved.extractorArgs,
+                infoJsonPath = resolved.infoJsonPath,
+            )
+        }.onFailure { error ->
+            logger.e("FormatExtractor", "Format load exception for URL: $url", error)
+        }
+    }
+
+    private suspend fun resolveBestAnalyzeCandidate(
+        url: String,
+        cookiesPath: String?,
+        userAgent: String?,
+        requestMode: AnalyzeRequestMode = resolveAnalyzeRequestMode(url),
+    ): AnalyzeCandidate {
+        val hasCookies = !cookiesPath.isNullOrBlank() && File(cookiesPath).exists()
+        val extractorCandidates = if (isYoutubeUrl(url)) {
+            YoutubeRequestPlanner.analyzeCandidates(cookiesAvailable = hasCookies)
+        } else {
+            listOf<String?>(null)
+        }
+
+        var best: AnalyzeCandidate? = null
+        var lastFailureMessage: String? = null
+        extractorCandidates.forEachIndexed { index, extractorArgs ->
+            if (requestMode == AnalyzeRequestMode.YOUTUBE_PLAYLIST_FAST &&
+                best?.isPlaylistResult == true &&
+                (best?.playlistEntryCount ?: 0) > 0
+            ) {
+                return@forEachIndexed
+            }
+            if (best != null && !shouldTryMoreCandidates(best?.stats)) return@forEachIndexed
+            val attempt = runCatching {
+                analyzeWithExtractor(
+                    url = url,
+                    extractorArgs = extractorArgs,
+                    cookiesPath = cookiesPath,
+                    userAgent = userAgent,
+                    requestMode = requestMode,
+                )
+            }.getOrElse { error ->
+                logger.w(
+                    "FormatExtractor",
+                    "Analyze candidate[$index] crashed for args=${extractorArgs ?: "(default)"}",
+                    error,
+                )
+                AnalyzeAttempt(
+                    candidate = null,
+                    errorMessage = sanitizeAnalyzeFailureMessage(
+                        error.message?.takeIf { it.isNotBlank() } ?: "yt-dlp analyze failed",
+                    ),
+                )
+            }
+            val candidate = attempt.candidate
+            if (candidate != null) {
+                val stats = candidate.stats
+                val descriptor = extractorArgs ?: "(default)"
+                if (requestMode == AnalyzeRequestMode.YOUTUBE_PLAYLIST_FAST) {
+                    logger.i(
+                        "FormatExtractor",
+                        "Analyze candidate[$index] args=$descriptor playlistEntries=${candidate.playlistEntryCount} playlist=${candidate.isPlaylistResult}",
+                    )
+                } else {
+                    logger.i(
+                        "FormatExtractor",
+                        "Analyze candidate[$index] args=$descriptor formats=${stats.total} videoOnly=${stats.videoOnly} audioOnly=${stats.audioOnly} maxHeight=${stats.maxHeight}",
+                    )
+                }
+                if (requestMode == AnalyzeRequestMode.YOUTUBE_PLAYLIST_FAST) {
+                    if (best == null || candidate.playlistEntryCount > (best?.playlistEntryCount ?: -1)) {
+                        best = candidate
+                    }
+                    if (candidate.isPlaylistResult && candidate.playlistEntryCount > 0) return@forEachIndexed
+                    return@forEachIndexed
+                }
+                if (best == null || stats.isBetterThan(best?.stats)) {
+                    best = candidate
+                }
+                if (stats.hasAdaptiveVideo) return@forEachIndexed
+            } else if (!attempt.errorMessage.isNullOrBlank()) {
+                lastFailureMessage = attempt.errorMessage
+            }
+        }
+
+        return best ?: throw IllegalStateException(lastFailureMessage ?: "yt-dlp analyze failed")
     }
 
     private fun logFormatSummary(url: String, formats: List<MediaFormat>, extractorArgs: String?) {
@@ -145,6 +211,71 @@ class FormatExtractor @Inject constructor(
         }
     }
 
+    private fun mapLinkAnalysis(
+        root: JsonObject,
+        fallbackUrl: String,
+        extractorArgs: String?,
+        infoJsonPath: String?,
+    ): LinkAnalysisResult {
+        val playlistEntries = parsePlaylistEntries(
+            entries = root["entries"] as? JsonArray,
+            playlistSourceUrl = fallbackUrl,
+        )
+        val rootFormats = extractFormats(root)
+        val webpageUrl = root["webpage_url"]?.jsonPrimitive?.contentOrNull ?: fallbackUrl
+        val sourceKind = resolveSourceKind(
+            fallbackUrl = fallbackUrl,
+            root = root,
+            playlistEntries = playlistEntries,
+        )
+        val items = if (playlistEntries.isNotEmpty()) {
+            playlistEntries.map { entry ->
+                LinkAnalysisItem(
+                    id = entry.id,
+                    title = entry.title,
+                    webpageUrl = entry.webpageUrl,
+                    uploader = entry.uploader,
+                    durationSeconds = entry.durationSeconds,
+                    thumbnailUrl = entry.thumbnailUrl,
+                    playlistItemIndex = entry.playlistItemIndex,
+                    formats = entry.formats,
+                    extractorArgs = extractorArgs,
+                    infoJsonPath = null,
+                )
+            }
+        } else {
+            listOf(
+                LinkAnalysisItem(
+                    id = root["id"]?.jsonPrimitive?.contentOrNull.orEmpty(),
+                    title = root["title"]?.jsonPrimitive?.contentOrNull ?: "Untitled",
+                    webpageUrl = webpageUrl,
+                    uploader = root["uploader"]?.jsonPrimitive?.contentOrNull,
+                    durationSeconds = root["duration"]?.jsonPrimitive?.longOrNull,
+                    thumbnailUrl = root["thumbnail"]?.jsonPrimitive?.contentOrNull,
+                    formats = rootFormats,
+                    extractorArgs = extractorArgs,
+                    infoJsonPath = infoJsonPath,
+                ),
+            )
+        }
+        return LinkAnalysisResult(
+            sourceKind = sourceKind,
+            input = fallbackUrl,
+            rootId = root["id"]?.jsonPrimitive?.contentOrNull.orEmpty(),
+            title = root["title"]?.jsonPrimitive?.contentOrNull ?: "Untitled",
+            uploader = root["uploader"]?.jsonPrimitive?.contentOrNull,
+            durationSeconds = root["duration"]?.jsonPrimitive?.longOrNull,
+            thumbnailUrl = root["thumbnail"]?.jsonPrimitive?.contentOrNull
+                ?: playlistEntries.firstOrNull()?.thumbnailUrl,
+            webpageUrl = webpageUrl,
+            rootFormats = rootFormats,
+            extractorArgs = extractorArgs,
+            infoJsonPath = infoJsonPath,
+            playlistCount = root["playlist_count"]?.jsonPrimitive?.intOrNull ?: playlistEntries.size.takeIf { it > 0 },
+            items = items,
+        )
+    }
+
     private fun mapVideoInfo(
         root: JsonObject,
         fallbackUrl: String,
@@ -155,11 +286,7 @@ class FormatExtractor @Inject constructor(
             entries = root["entries"] as? JsonArray,
             playlistSourceUrl = fallbackUrl,
         )
-        val rootFormats = parseFormats(root["formats"] as? JsonArray ?: JsonArray(emptyList()))
-        val fallbackFormats = firstEntryWithFormats(root["entries"] as? JsonArray)
-            ?.let(::parseFormats)
-            .orEmpty()
-        val formats = rootFormats.ifEmpty { fallbackFormats }
+        val formats = extractFormats(root)
         val type = root["\u005ftype"]?.jsonPrimitive?.contentOrNull
         return VideoInfo(
             id = root["id"]?.jsonPrimitive?.contentOrNull.orEmpty(),
@@ -176,6 +303,30 @@ class FormatExtractor @Inject constructor(
             playlistCount = root["playlist_count"]?.jsonPrimitive?.intOrNull ?: playlistEntries.size.takeIf { it > 0 },
             playlistEntries = playlistEntries,
         )
+    }
+
+    private fun extractFormats(root: JsonObject): List<MediaFormat> {
+        val rootFormats = parseFormats(root["formats"] as? JsonArray ?: JsonArray(emptyList()))
+        val fallbackFormats = firstEntryWithFormats(root["entries"] as? JsonArray)
+            ?.let(::parseFormats)
+            .orEmpty()
+        return rootFormats.ifEmpty { fallbackFormats }
+    }
+
+    private fun resolveSourceKind(
+        fallbackUrl: String,
+        root: JsonObject,
+        playlistEntries: List<PlaylistEntry>,
+    ): LinkSourceKind {
+        val type = root["_type"]?.jsonPrimitive?.contentOrNull
+        if (type == "playlist" || playlistEntries.isNotEmpty()) {
+            return if (LinkSourceClassifier.classify(fallbackUrl) == LinkSourceKind.CHANNEL) {
+                LinkSourceKind.CHANNEL
+            } else {
+                LinkSourceKind.PLAYLIST
+            }
+        }
+        return LinkSourceClassifier.classify(fallbackUrl)
     }
 
     private fun parsePlaylistEntries(

--- a/app/src/main/java/com/localdownloader/downloader/LinkSourceClassifier.kt
+++ b/app/src/main/java/com/localdownloader/downloader/LinkSourceClassifier.kt
@@ -1,0 +1,31 @@
+package com.localdownloader.downloader
+
+import com.localdownloader.domain.models.LinkSourceKind
+
+/**
+ * Centralized source classification for URL-based discovery.
+ */
+object LinkSourceClassifier {
+    fun classify(input: String): LinkSourceKind {
+        val normalized = input.trim().lowercase()
+        if (normalized.isBlank()) return LinkSourceKind.GENERIC_URL
+        if (!normalized.startsWith("http://") && !normalized.startsWith("https://")) {
+            return LinkSourceKind.GENERIC_URL
+        }
+        if (looksLikeYoutubeUrl(normalized)) {
+            if (normalized.contains("list=") || normalized.contains("/playlist")) {
+                return LinkSourceKind.PLAYLIST
+            }
+            if (
+                normalized.contains("/channel/") ||
+                normalized.contains("/c/") ||
+                normalized.contains("/user/") ||
+                normalized.contains("/@")
+            ) {
+                return LinkSourceKind.CHANNEL
+            }
+            return LinkSourceKind.SINGLE_VIDEO
+        }
+        return LinkSourceKind.GENERIC_URL
+    }
+}

--- a/app/src/main/java/com/localdownloader/downloader/YoutubeRequestPlanner.kt
+++ b/app/src/main/java/com/localdownloader/downloader/YoutubeRequestPlanner.kt
@@ -22,6 +22,18 @@ object YoutubeRequestPlanner {
         return candidates.distinct()
     }
 
+    fun discoveryCandidates(cookiesAvailable: Boolean): List<String?> {
+        val candidates = buildList {
+            add(buildExtractorArgs(clientSpec = "default,mweb", includePlayerSkip = true))
+            add(buildExtractorArgs(clientSpec = "default,web", includePlayerSkip = true))
+            add(null)
+            if (cookiesAvailable) {
+                add(buildExtractorArgs(clientSpec = "default,mweb,web,android,tv", includePlayerSkip = true))
+            }
+        }
+        return candidates.distinct()
+    }
+
     fun recoveryCandidates(selectedExtractorArgs: String?, cookiesAvailable: Boolean): List<String?> {
         val normalizedSelectedArgs = normalizeExtractorArgs(selectedExtractorArgs)
         return analyzeCandidates(cookiesAvailable)

--- a/app/src/main/java/com/localdownloader/ui/DownloaderApp.kt
+++ b/app/src/main/java/com/localdownloader/ui/DownloaderApp.kt
@@ -445,6 +445,7 @@ fun DownloaderApp(
                     onPlaylistItemFileNameChanged = formatViewModel::onPlaylistItemFileNameChanged,
                     onOutputTemplateChanged = formatViewModel::onOutputTemplateChanged,
                     onAudioOutputTemplateChanged = formatViewModel::onAudioOutputTemplateChanged,
+                    onPrepareDownloadClicked = formatViewModel::prepareCurrentLinkForDownload,
                     onClearBrowserState = formatViewModel::clearBrowserState,
                     onClearAnalyzedResult = formatViewModel::clearAnalyzedResult,
                     onOpenReadyItem = formatViewModel::reopenReadyItem,
@@ -462,6 +463,7 @@ fun DownloaderApp(
                     onDismissMeteredNetworkDialog = formatViewModel::dismissMeteredNetworkDialog,
                     onQueueWhenWifiAvailable = formatViewModel::queueDownloadWhenWifiAvailable,
                     onAllowCellularDownloadsAndQueue = formatViewModel::allowCellularDownloadsAndQueue,
+                    onOptionsSheetRequestConsumed = formatViewModel::consumeOptionsSheetRequest,
                     onDarkThemeChanged = formatViewModel::toggleDarkTheme,
                     isDownloadButtonEnabled = formatViewModel.isDownloadButtonEnabled(),
                 )

--- a/app/src/main/java/com/localdownloader/ui/screens/BrowserScreen.kt
+++ b/app/src/main/java/com/localdownloader/ui/screens/BrowserScreen.kt
@@ -91,6 +91,7 @@ import com.localdownloader.downloader.isAutomaticContainerSelection
 import com.localdownloader.downloader.isChoiceCompatibleWithRequestedContainer
 import com.localdownloader.downloader.resolveMergeContainerCompatibility
 import com.localdownloader.domain.models.FormatChoice
+import com.localdownloader.domain.models.LinkAnalysisResult
 import com.localdownloader.domain.models.OutputTransform
 import com.localdownloader.domain.models.StreamType
 import com.localdownloader.domain.models.VideoQuality
@@ -145,6 +146,7 @@ fun BrowserScreen(
     onPlaylistItemFileNameChanged: (Int, String) -> Unit,
     onOutputTemplateChanged: (String) -> Unit,
     onAudioOutputTemplateChanged: (String) -> Unit,
+    onPrepareDownloadClicked: () -> Unit,
     onClearBrowserState: () -> Unit,
     onClearAnalyzedResult: () -> Unit,
     onOpenReadyItem: (String) -> Unit,
@@ -162,6 +164,7 @@ fun BrowserScreen(
     onDismissMeteredNetworkDialog: () -> Unit,
     onQueueWhenWifiAvailable: () -> Unit,
     onAllowCellularDownloadsAndQueue: () -> Unit,
+    onOptionsSheetRequestConsumed: () -> Unit,
     onDarkThemeChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     isDownloadButtonEnabled: Boolean = true,
@@ -204,8 +207,11 @@ fun BrowserScreen(
         )
     }
 
-    LaunchedEffect(uiState.videoInfo?.webpageUrl, uiState.shouldShowDownloadSetupNotice) {
-        showOptionsSheet = uiState.videoInfo != null && !uiState.shouldShowDownloadSetupNotice
+    LaunchedEffect(uiState.shouldOpenOptionsSheet, uiState.shouldShowDownloadSetupNotice) {
+        if (uiState.shouldOpenOptionsSheet && !uiState.shouldShowDownloadSetupNotice) {
+            showOptionsSheet = true
+            onOptionsSheetRequestConsumed()
+        }
     }
 
     LaunchedEffect(uiState.shouldShowDownloadSetupNotice) {
@@ -431,15 +437,34 @@ fun BrowserScreen(
             }
         }
 
+        uiState.linkAnalysis?.let { analysis ->
+            DiscoveredResultsCard(
+                analysis = analysis,
+                isLoading = uiState.isLoadingFormats,
+                isReady = uiState.videoInfo != null && !uiState.isLoadingFormats,
+                onDownload = onPrepareDownloadClicked,
+            )
+        }
+
+        val currentAnalysisUrl = uiState.linkAnalysis?.let { analysis ->
+            if (analysis.isCollection) {
+                analysis.webpageUrl ?: analysis.input
+            } else {
+                analysis.primaryItem?.webpageUrl ?: analysis.webpageUrl ?: analysis.input
+            }
+        }
+        val visibleReadyItems = uiState.readyAnalyzedItems.filterNot { item ->
+            currentAnalysisUrl != null && item.webpageUrl == currentAnalysisUrl
+        }
         AnimatedVisibility(
-            visible = uiState.readyAnalyzedItems.isNotEmpty(),
+            visible = visibleReadyItems.isNotEmpty(),
             enter = fadeIn(animationSpec = tween(durationMillis = 220)) +
                 expandVertically(animationSpec = tween(durationMillis = 260, easing = FastOutSlowInEasing)),
             exit = fadeOut(animationSpec = tween(durationMillis = 160)) +
                 shrinkVertically(animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing)),
         ) {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                uiState.readyAnalyzedItems.forEach { item ->
+                visibleReadyItems.forEach { item ->
                     ReadyAnalyzedCard(
                         item = item,
                         isActive = uiState.videoInfo?.webpageUrl == item.webpageUrl,
@@ -961,6 +986,167 @@ private fun ReadyAnalyzedCard(
                             },
                         )
                     }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DiscoveredResultsCard(
+    analysis: LinkAnalysisResult,
+    isLoading: Boolean,
+    isReady: Boolean,
+    onDownload: () -> Unit,
+) {
+    val previewItems = if (analysis.isCollection) analysis.items.take(20) else emptyList()
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .animateContentSize(
+                animationSpec = spring(
+                    dampingRatio = 0.9f,
+                    stiffness = 500f,
+                ),
+            ),
+        shape = RoundedCornerShape(26.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = if (analysis.isCollection) "Found files" else "Found file",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    listOfNotNull(
+                        if (analysis.isCollection) "${analysis.playlistCount ?: analysis.items.size} items" else null,
+                        playlistDurationLabel(analysis.durationSeconds),
+                    ).forEach { chip ->
+                        BrowserMetaChip(text = chip)
+                    }
+                }
+            }
+
+            Surface(
+                shape = RoundedCornerShape(22.dp),
+                color = MaterialTheme.colorScheme.surfaceContainerLow,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    AsyncImage(
+                        model = analysis.thumbnailUrl ?: analysis.primaryItem?.thumbnailUrl,
+                        contentDescription = analysis.title,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .size(width = 120.dp, height = 68.dp),
+                    )
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Text(
+                            text = analysis.title,
+                            style = MaterialTheme.typography.titleMedium,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = analysis.uploader
+                                ?: analysis.primaryItem?.uploader
+                                ?: stringResource(R.string.common_unknown_uploader),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+
+            Button(
+                onClick = onDownload,
+                enabled = !isLoading,
+                modifier = Modifier.fillMaxWidth(),
+                contentPadding = PaddingValues(vertical = 14.dp),
+            ) {
+                Text(
+                    when {
+                        isLoading -> "Loading options..."
+                        isReady -> stringResource(R.string.browser_open_options)
+                        else -> stringResource(R.string.browser_download_button)
+                    },
+                )
+            }
+
+            if (previewItems.isNotEmpty()) {
+                Text(
+                    text = if (analysis.isCollection) "Files" else "File",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                previewItems.forEach { item ->
+                    Surface(
+                        shape = RoundedCornerShape(20.dp),
+                        color = MaterialTheme.colorScheme.surfaceContainerLow,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(12.dp),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            AsyncImage(
+                                model = item.thumbnailUrl ?: analysis.thumbnailUrl,
+                                contentDescription = item.title,
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier
+                                    .size(width = 92.dp, height = 52.dp),
+                            )
+                            Column(
+                                modifier = Modifier.weight(1f),
+                                verticalArrangement = Arrangement.spacedBy(4.dp),
+                            ) {
+                                Text(
+                                    text = item.title,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                                Text(
+                                    text = item.uploader
+                                        ?: analysis.uploader
+                                        ?: stringResource(R.string.common_unknown_uploader),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+                            playlistDurationLabel(item.durationSeconds)?.let { duration ->
+                                BrowserMetaChip(text = duration)
+                            }
+                        }
+                    }
+                }
+                if (analysis.isCollection && analysis.items.size > previewItems.size) {
+                    Text(
+                        text = "Showing first ${previewItems.size} of ${analysis.items.size} files.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/localdownloader/ui/screens/BrowserScreen.kt
+++ b/app/src/main/java/com/localdownloader/ui/screens/BrowserScreen.kt
@@ -344,7 +344,7 @@ fun BrowserScreen(
                     },
                 )
                 AnimatedVisibility(
-                    visible = uiState.isAnalyzing,
+                    visible = uiState.isAnalyzing || uiState.isLoadingFormats,
                     enter = fadeIn(animationSpec = tween(durationMillis = 180)) +
                         expandVertically(animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing)),
                     exit = fadeOut(animationSpec = tween(durationMillis = 140)) +
@@ -383,19 +383,16 @@ fun BrowserScreen(
                     }
                     Button(
                         onClick = onAnalyzeClicked,
-                        enabled = !uiState.isAnalyzing,
+                        enabled = !uiState.isAnalyzing && !uiState.isLoadingFormats,
                         modifier = Modifier.weight(1f),
                         contentPadding = PaddingValues(vertical = 14.dp),
                     ) {
-                        Text(
-                            stringResource(
-                                if (uiState.isAnalyzing) {
-                                    R.string.browser_analyzing
-                                } else {
-                                    R.string.browser_analyze_link
-                                },
-                            ),
-                        )
+                        val buttonText = when {
+                            uiState.isAnalyzing -> stringResource(R.string.browser_analyzing)
+                            uiState.isLoadingFormats -> "Loading formats..."
+                            else -> stringResource(R.string.browser_analyze_link)
+                        }
+                        Text(buttonText)
                     }
                 }
             }
@@ -446,7 +443,8 @@ fun BrowserScreen(
                     ReadyAnalyzedCard(
                         item = item,
                         isActive = uiState.videoInfo?.webpageUrl == item.webpageUrl,
-                        isLoading = uiState.restoringReadyItemUrl == item.webpageUrl && uiState.isAnalyzing,
+                        isLoading = uiState.restoringReadyItemUrl == item.webpageUrl &&
+                            (uiState.isAnalyzing || uiState.isLoadingFormats),
                         onOpen = {
                             if (uiState.videoInfo?.webpageUrl == item.webpageUrl) {
                                 showOptionsSheet = true

--- a/app/src/main/java/com/localdownloader/viewmodel/FormatUiState.kt
+++ b/app/src/main/java/com/localdownloader/viewmodel/FormatUiState.kt
@@ -70,6 +70,7 @@ data class FormatUiState(
     val urlInput: String = "",
     val isAnalyzing: Boolean = false,
     val isLoadingFormats: Boolean = false,
+    val shouldOpenOptionsSheet: Boolean = false,
     val isQueueing: Boolean = false,
     val linkAnalysis: LinkAnalysisResult? = null,
     val videoInfo: VideoInfo? = null,

--- a/app/src/main/java/com/localdownloader/viewmodel/FormatUiState.kt
+++ b/app/src/main/java/com/localdownloader/viewmodel/FormatUiState.kt
@@ -6,6 +6,8 @@ import com.localdownloader.domain.models.AppSettings
 import com.localdownloader.domain.models.ContrastMode
 import com.localdownloader.domain.models.CookieProfile
 import com.localdownloader.domain.models.FormatChoice
+import com.localdownloader.domain.models.FormatViewMode
+import com.localdownloader.domain.models.LinkAnalysisResult
 import com.localdownloader.domain.models.OutputTransform
 import com.localdownloader.domain.models.PlaylistEntry
 import com.localdownloader.domain.models.SYSTEM_LANGUAGE_TAG
@@ -67,7 +69,9 @@ data class PlaylistItemUiState(
 data class FormatUiState(
     val urlInput: String = "",
     val isAnalyzing: Boolean = false,
+    val isLoadingFormats: Boolean = false,
     val isQueueing: Boolean = false,
+    val linkAnalysis: LinkAnalysisResult? = null,
     val videoInfo: VideoInfo? = null,
     val availableVideoAudioChoices: List<FormatChoice> = emptyList(),
     val availableVideoOnlyChoices: List<FormatChoice> = emptyList(),
@@ -77,6 +81,7 @@ data class FormatUiState(
     val selectedQuality: VideoQuality = VideoQuality.BEST,
     val selectedStreamType: StreamType = StreamType.VIDEO_AUDIO,
     val selectedOutputTransform: OutputTransform = OutputTransform.NONE,
+    val formatViewMode: FormatViewMode = FormatViewMode.SUGGESTED,
     val selectedContainer: String = "auto",
     val selectedAudioFormat: String = "mp3",
     val audioBitrateKbps: Int = 192,
@@ -111,6 +116,7 @@ data class FormatUiState(
     val cookieProfiles: List<CookieProfile> = emptyList(),
     val youtubeAuthConfig: YoutubeAuthConfig = YoutubeAuthConfig(),
     val playlistItems: List<PlaylistItemUiState> = emptyList(),
+    val selectedBrowseItemUrl: String? = null,
     val readyAnalyzedItems: List<AnalyzedLinkRecord> = emptyList(),
     val restoringReadyItemUrl: String? = null,
     val appSettings: AppSettings = AppSettings(),

--- a/app/src/main/java/com/localdownloader/viewmodel/FormatViewModel.kt
+++ b/app/src/main/java/com/localdownloader/viewmodel/FormatViewModel.kt
@@ -2198,7 +2198,7 @@ class FormatViewModel @Inject constructor(
         isLoadingFormats: Boolean,
     ): String {
         val status = when {
-            isLoadingFormats -> "Loading download options..."
+            isLoadingFormats -> "Download options are open. Exact formats are still loading..."
             info.isPlaylist -> {
                 val itemCount = info.playlistCount ?: info.playlistEntries.size
                 val hasLoadedPlaylistFormats = info.formats.isNotEmpty() ||
@@ -2255,7 +2255,7 @@ class FormatViewModel @Inject constructor(
             state.copy(
                 isAnalyzing = false,
                 isLoadingFormats = keepLoadingFormats,
-                shouldOpenOptionsSheet = openOptionsOnReady && !keepLoadingFormats,
+                shouldOpenOptionsSheet = openOptionsOnReady,
                 messageScope = FormatMessageScope.BROWSER,
                 linkAnalysis = analysis,
                 videoInfo = info,
@@ -2273,10 +2273,14 @@ class FormatViewModel @Inject constructor(
                     info.title
                 },
                 enablePlaylist = state.enablePlaylist || info.isPlaylist,
-                readyAnalyzedItems = upsertReadyRecord(
-                    state.readyAnalyzedItems,
-                    buildReadyRecord(info),
-                ),
+                readyAnalyzedItems = if (keepLoadingFormats) {
+                    state.readyAnalyzedItems
+                } else {
+                    upsertReadyRecord(
+                        state.readyAnalyzedItems,
+                        buildReadyRecord(info),
+                    )
+                },
                 restoringReadyItemUrl = null,
                 infoMessage = buildAnalyzeSuccessMessage(
                     info = info,
@@ -2295,20 +2299,25 @@ class FormatViewModel @Inject constructor(
         upgradeNotice: String?,
         openOptionsOnReady: Boolean,
     ) {
-        _uiState.update { state ->
-            state.copy(
-                isAnalyzing = false,
-                isLoadingFormats = true,
-                shouldOpenOptionsSheet = false,
-                selectedBrowseItemUrl = selectionUrl,
-                messageScope = FormatMessageScope.BROWSER,
-                errorMessage = null,
-                infoMessage = if (analysis.isCollection) {
-                    "Loading collection download options..."
-                } else {
-                    "Loading download options..."
-                },
-            )
+        val initialInfo = analysis.toLegacyVideoInfo()
+        val requiresDeferredFormatLoading = if (analysis.isCollection) {
+            initialInfo.playlistEntries.any { it.formats.isEmpty() }
+        } else {
+            initialInfo.formats.isEmpty()
+        }
+
+        applyAnalyzedInfo(
+            analysis = analysis,
+            info = initialInfo,
+            upgradeNotice = upgradeNotice,
+            keepLoadingFormats = requiresDeferredFormatLoading,
+            selectedBrowseUrl = selectionUrl,
+            openOptionsOnReady = openOptionsOnReady,
+        )
+
+        if (!requiresDeferredFormatLoading) {
+            persistReadyRecordIfNeeded(initialInfo)
+            return
         }
 
         val result = if (analysis.isCollection) {
@@ -2358,7 +2367,7 @@ class FormatViewModel @Inject constructor(
                     upgradeNotice = upgradeNotice,
                     keepLoadingFormats = false,
                     selectedBrowseUrl = selectionUrl,
-                    openOptionsOnReady = openOptionsOnReady,
+                    openOptionsOnReady = false,
                 )
                 persistReadyRecordIfNeeded(updatedInfo)
             },

--- a/app/src/main/java/com/localdownloader/viewmodel/FormatViewModel.kt
+++ b/app/src/main/java/com/localdownloader/viewmodel/FormatViewModel.kt
@@ -16,9 +16,11 @@ import com.localdownloader.domain.models.ContrastMode
 import com.localdownloader.domain.models.CookieProfile
 import com.localdownloader.domain.models.DownloadOptions
 import com.localdownloader.domain.models.FormatChoice
+import com.localdownloader.domain.models.LinkAnalysisResult
 import com.localdownloader.domain.models.MediaFormat
 import com.localdownloader.domain.models.OutputTransform
 import com.localdownloader.domain.models.PlaylistDownloadRequest
+import com.localdownloader.domain.models.PlaylistEntry
 import com.localdownloader.domain.models.SYSTEM_LANGUAGE_TAG
 import com.localdownloader.domain.models.StreamType
 import com.localdownloader.domain.models.ThemeMode
@@ -91,13 +93,16 @@ class FormatViewModel @Inject constructor(
             state.copy(
                 urlInput = "",
                 isAnalyzing = false,
+                isLoadingFormats = false,
                 isQueueing = false,
+                linkAnalysis = null,
                 videoInfo = null,
                 availableVideoAudioChoices = emptyList(),
                 availableVideoOnlyChoices = emptyList(),
                 availableAudioOnlyChoices = emptyList(),
                 playlistItems = emptyList(),
                 selectedFormatSelector = null,
+                selectedBrowseItemUrl = null,
                 customFileName = "",
                 infoMessage = null,
                 errorMessage = null,
@@ -115,13 +120,16 @@ class FormatViewModel @Inject constructor(
             val removedCurrent = state.videoInfo?.webpageUrl == webpageUrl
             state.copy(
                 isAnalyzing = false,
+                isLoadingFormats = false,
                 isQueueing = false,
+                linkAnalysis = if (removedCurrent) null else state.linkAnalysis,
                 videoInfo = if (removedCurrent) null else state.videoInfo,
                 availableVideoAudioChoices = if (removedCurrent) emptyList() else state.availableVideoAudioChoices,
                 availableVideoOnlyChoices = if (removedCurrent) emptyList() else state.availableVideoOnlyChoices,
                 availableAudioOnlyChoices = if (removedCurrent) emptyList() else state.availableAudioOnlyChoices,
                 playlistItems = if (removedCurrent) emptyList() else state.playlistItems,
                 selectedFormatSelector = if (removedCurrent) null else state.selectedFormatSelector,
+                selectedBrowseItemUrl = if (removedCurrent) null else state.selectedBrowseItemUrl,
                 customFileName = if (removedCurrent) "" else state.customFileName,
                 readyAnalyzedItems = state.readyAnalyzedItems.filterNot { it.webpageUrl == webpageUrl },
                 restoringReadyItemUrl = if (state.restoringReadyItemUrl == webpageUrl) null else state.restoringReadyItemUrl,
@@ -198,14 +206,17 @@ class FormatViewModel @Inject constructor(
                 state.copy(
                     urlInput = secureUrl,
                     isAnalyzing = true,
+                    isLoadingFormats = false,
                     errorMessage = null,
                     infoMessage = upgradeNotice,
+                    linkAnalysis = null,
                     videoInfo = null,
                     availableVideoAudioChoices = emptyList(),
                     availableVideoOnlyChoices = emptyList(),
                     availableAudioOnlyChoices = emptyList(),
                     playlistItems = emptyList(),
                     selectedFormatSelector = null,
+                    selectedBrowseItemUrl = null,
                     customFileName = "",
                     restoringReadyItemUrl = if (restoreIntoReady) secureUrl else state.restoringReadyItemUrl,
                 )
@@ -213,7 +224,7 @@ class FormatViewModel @Inject constructor(
 
             val runtimeCookiesPath = resolveRuntimeCookiesPathForUrl(secureUrl)
             val result = runCatching {
-                repository.analyzeUrl(
+                repository.analyzeLink(
                     url = secureUrl,
                     cookiesPath = runtimeCookiesPath,
                     userAgent = if (uiState.value.cookiesEnabled && uiState.value.cookieUserAgentEnabled) {
@@ -227,7 +238,8 @@ class FormatViewModel @Inject constructor(
                     Result.failure(IllegalStateException(throwable.message ?: "Analyze failed", throwable))
                 }
             result.fold(
-                onSuccess = { info ->
+                onSuccess = { analysis ->
+                    val info = analysis.toLegacyVideoInfo()
                     logger.i(
                         "FormatViewModel",
                         "Analyze success for URL: $secureUrl, title='${info.title}', formats=${info.formats.size}",
@@ -264,6 +276,7 @@ class FormatViewModel @Inject constructor(
                         state.copy(
                             isAnalyzing = false,
                             messageScope = FormatMessageScope.BROWSER,
+                            linkAnalysis = analysis,
                             videoInfo = info,
                             availableVideoAudioChoices = choiceBundle.videoAudioChoices,
                             availableVideoOnlyChoices = choiceBundle.videoOnlyChoices,
@@ -272,6 +285,7 @@ class FormatViewModel @Inject constructor(
                             selectedStreamType = resolvedStreamType,
                             selectedOutputTransform = resolvedOutputTransform,
                             selectedFormatSelector = selectedSelector,
+                            selectedBrowseItemUrl = analysis.primaryItem?.webpageUrl ?: info.webpageUrl,
                             customFileName = info.title,
                             enablePlaylist = state.enablePlaylist || info.isPlaylist,
                             readyAnalyzedItems = upsertReadyRecord(
@@ -310,6 +324,7 @@ class FormatViewModel @Inject constructor(
                                     append(" Ensure yt-dlp runtime is initialized and this device ABI is supported.")
                                 }
                             },
+                            linkAnalysis = null,
                             restoringReadyItemUrl = null,
                         )
                     }
@@ -2020,6 +2035,38 @@ class FormatViewModel @Inject constructor(
         val request: PlaylistDownloadRequest,
         val queueNote: String?,
     )
+
+    private fun LinkAnalysisResult.toLegacyVideoInfo(): VideoInfo {
+        val playlistEntries = items.mapIndexed { index, item ->
+            PlaylistEntry(
+                playlistItemIndex = item.playlistItemIndex ?: index + 1,
+                id = item.id,
+                title = item.title,
+                webpageUrl = item.webpageUrl,
+                uploader = item.uploader,
+                durationSeconds = item.durationSeconds,
+                thumbnailUrl = item.thumbnailUrl,
+                formats = item.formats,
+            )
+        }
+        val primaryItem = primaryItem
+        val resolvedWebpageUrl = webpageUrl ?: primaryItem?.webpageUrl ?: input
+        val resolvedFormats = rootFormats.ifEmpty { primaryItem?.formats.orEmpty() }
+        return VideoInfo(
+            id = rootId.ifBlank { primaryItem?.id.orEmpty() },
+            title = title,
+            uploader = uploader ?: primaryItem?.uploader,
+            durationSeconds = durationSeconds ?: primaryItem?.durationSeconds,
+            thumbnailUrl = thumbnailUrl ?: primaryItem?.thumbnailUrl,
+            webpageUrl = resolvedWebpageUrl,
+            formats = resolvedFormats,
+            extractorArgs = extractorArgs ?: primaryItem?.extractorArgs,
+            infoJsonPath = infoJsonPath ?: primaryItem?.infoJsonPath,
+            isPlaylist = isCollection,
+            playlistCount = playlistCount ?: items.size.takeIf { isCollection },
+            playlistEntries = playlistEntries,
+        )
+    }
 
     private fun buildPlaylistItemStates(
         info: VideoInfo,

--- a/app/src/main/java/com/localdownloader/viewmodel/FormatViewModel.kt
+++ b/app/src/main/java/com/localdownloader/viewmodel/FormatViewModel.kt
@@ -2022,6 +2022,7 @@ class FormatViewModel @Inject constructor(
 
     private fun LinkAnalysisResult.withLoadedFormats(result: FormatLoadResult): LinkAnalysisResult {
         val targetUrl = result.webpageUrl
+        val existingPrimaryItem = primaryItem
         val updatedItems = items.map { item ->
             if (item.webpageUrl == targetUrl) {
                 item.copy(
@@ -2042,11 +2043,11 @@ class FormatViewModel @Inject constructor(
             infoJsonPath = result.infoJsonPath ?: infoJsonPath,
             items = updatedItems.ifEmpty {
                 listOfNotNull(
-                    primaryUpdated ?: primaryItem?.copy(
-                        title = result.title.ifBlank { primaryItem.title },
+                    primaryUpdated ?: existingPrimaryItem?.copy(
+                        title = result.title.ifBlank { existingPrimaryItem.title },
                         formats = result.formats,
-                        extractorArgs = result.extractorArgs ?: primaryItem.extractorArgs,
-                        infoJsonPath = result.infoJsonPath ?: primaryItem.infoJsonPath,
+                        extractorArgs = result.extractorArgs ?: existingPrimaryItem.extractorArgs,
+                        infoJsonPath = result.infoJsonPath ?: existingPrimaryItem.infoJsonPath,
                     ),
                 )
             },

--- a/app/src/main/java/com/localdownloader/viewmodel/FormatViewModel.kt
+++ b/app/src/main/java/com/localdownloader/viewmodel/FormatViewModel.kt
@@ -96,6 +96,7 @@ class FormatViewModel @Inject constructor(
                 urlInput = "",
                 isAnalyzing = false,
                 isLoadingFormats = false,
+                shouldOpenOptionsSheet = false,
                 isQueueing = false,
                 linkAnalysis = null,
                 videoInfo = null,
@@ -123,6 +124,7 @@ class FormatViewModel @Inject constructor(
             state.copy(
                 isAnalyzing = false,
                 isLoadingFormats = false,
+                shouldOpenOptionsSheet = false,
                 isQueueing = false,
                 linkAnalysis = if (removedCurrent) null else state.linkAnalysis,
                 videoInfo = if (removedCurrent) null else state.videoInfo,
@@ -209,6 +211,7 @@ class FormatViewModel @Inject constructor(
                     urlInput = secureUrl,
                     isAnalyzing = true,
                     isLoadingFormats = false,
+                    shouldOpenOptionsSheet = false,
                     errorMessage = null,
                     infoMessage = upgradeNotice,
                     linkAnalysis = null,
@@ -241,25 +244,22 @@ class FormatViewModel @Inject constructor(
             }
             result.fold(
                 onSuccess = { analysis ->
-                    val info = analysis.toLegacyVideoInfo()
-                    logger.i("FormatViewModel", "Analyze success for URL: $secureUrl, title='${info.title}', formats=${info.formats.size}")
-                    val shouldLoadFormatsInBackground =
-                        analysis.sourceKind == LinkSourceKind.SINGLE_VIDEO && info.formats.isEmpty()
-                    applyAnalyzedInfo(
-                        analysis = analysis,
-                        info = info,
-                        upgradeNotice = upgradeNotice,
-                        keepLoadingFormats = shouldLoadFormatsInBackground,
+                    logger.i(
+                        "FormatViewModel",
+                        "Analyze success for URL: $secureUrl, title='${analysis.title}', items=${analysis.items.size}, source=${analysis.sourceKind}",
                     )
-                    if (shouldLoadFormatsInBackground) {
-                        loadFormatsForDiscoveredLink(
+                    applyDiscoveredAnalysis(
+                        analysis = analysis,
+                        upgradeNotice = upgradeNotice,
+                    )
+                    if (restoreIntoReady) {
+                        prepareDownloadOptionsForAnalysis(
                             analysis = analysis,
-                            secureUrl = secureUrl,
+                            selectionUrl = browseActionUrlFor(analysis),
                             runtimeCookiesPath = runtimeCookiesPath,
                             upgradeNotice = upgradeNotice,
+                            openOptionsOnReady = true,
                         )
-                    } else {
-                        persistReadyRecordIfNeeded(info)
                     }
                 },
                 onFailure = { error ->
@@ -269,6 +269,7 @@ class FormatViewModel @Inject constructor(
                         state.copy(
                             isAnalyzing = false,
                             isLoadingFormats = false,
+                            shouldOpenOptionsSheet = false,
                             messageScope = FormatMessageScope.BROWSER,
                             errorMessage = buildString {
                                 append(baseMessage)
@@ -283,6 +284,60 @@ class FormatViewModel @Inject constructor(
                 },
             )
         }
+    }
+
+    fun prepareCurrentLinkForDownload() {
+        val state = uiState.value
+        val analysis = state.linkAnalysis
+        if (analysis == null) {
+            if (state.videoInfo != null) {
+                _uiState.update { current ->
+                    current.copy(
+                        shouldOpenOptionsSheet = true,
+                        errorMessage = null,
+                    )
+                }
+            } else {
+                _uiState.update { current ->
+                    scopedMessageState(
+                        state = current,
+                        scope = FormatMessageScope.BROWSER,
+                        errorMessage = "Analyze a link first.",
+                    )
+                }
+            }
+            return
+        }
+
+        val selectionUrl = browseActionUrlFor(analysis)
+        if (
+            state.videoInfo != null &&
+            state.selectedBrowseItemUrl == selectionUrl &&
+            !state.isLoadingFormats
+        ) {
+            _uiState.update { current ->
+                current.copy(
+                    shouldOpenOptionsSheet = true,
+                    errorMessage = null,
+                )
+            }
+            return
+        }
+
+        val runtimeCookiesPath = resolveRuntimeCookiesPathForUrl(selectionUrl)
+        viewModelScope.launch {
+            prepareDownloadOptionsForAnalysis(
+                analysis = analysis,
+                selectionUrl = selectionUrl,
+                runtimeCookiesPath = runtimeCookiesPath,
+                upgradeNotice = null,
+                openOptionsOnReady = true,
+            )
+        }
+    }
+
+    fun consumeOptionsSheetRequest() {
+        _uiState.update { state -> state.copy(shouldOpenOptionsSheet = false) }
     }
 
     fun onQualityChanged(quality: VideoQuality) {
@@ -2054,19 +2109,103 @@ class FormatViewModel @Inject constructor(
         )
     }
 
+    private fun LinkAnalysisResult.withLoadedFormats(results: List<FormatLoadResult>): LinkAnalysisResult {
+        val updated = results.fold(this) { current, result ->
+            current.withLoadedFormats(result)
+        }
+        if (!updated.isCollection) {
+            return updated
+        }
+        return updated.copy(
+            rootFormats = aggregateCollectionFormats(updated.items),
+        )
+    }
+
+    private fun aggregateCollectionFormats(items: List<LinkAnalysisItem>): List<MediaFormat> {
+        return items
+            .flatMap { it.formats }
+            .distinctBy { format ->
+                listOf(
+                    format.formatId,
+                    format.extension,
+                    format.resolution.orEmpty(),
+                    format.videoCodec,
+                    format.audioCodec,
+                    format.note.orEmpty(),
+                ).joinToString("|")
+            }
+            .sortedWith(
+                compareByDescending<MediaFormat> { parseHeight(it.resolution) ?: 0 }
+                    .thenByDescending { it.bitrateKbps ?: 0 },
+            )
+    }
+
+    private fun browseActionUrlFor(analysis: LinkAnalysisResult): String {
+        return if (analysis.isCollection) {
+            analysis.webpageUrl ?: analysis.input
+        } else {
+            analysis.primaryItem?.webpageUrl ?: analysis.webpageUrl ?: analysis.input
+        }
+    }
+
+    private fun buildDiscoverySuccessMessage(
+        analysis: LinkAnalysisResult,
+        upgradeNotice: String?,
+    ): String {
+        val status = when {
+            analysis.isCollection -> {
+                val itemCount = analysis.playlistCount ?: analysis.items.size
+                "Found $itemCount items. Tap Download to choose options."
+            }
+            else -> "Link found. Tap Download to choose options."
+        }
+        return listOfNotNull(upgradeNotice, status).joinToString(" ")
+    }
+
+    private fun applyDiscoveredAnalysis(
+        analysis: LinkAnalysisResult,
+        upgradeNotice: String?,
+    ) {
+        _uiState.update { state ->
+            state.copy(
+                isAnalyzing = false,
+                isLoadingFormats = false,
+                shouldOpenOptionsSheet = false,
+                messageScope = FormatMessageScope.BROWSER,
+                linkAnalysis = analysis,
+                videoInfo = null,
+                availableVideoAudioChoices = emptyList(),
+                availableVideoOnlyChoices = emptyList(),
+                availableAudioOnlyChoices = emptyList(),
+                playlistItems = emptyList(),
+                selectedFormatSelector = null,
+                selectedBrowseItemUrl = null,
+                customFileName = "",
+                restoringReadyItemUrl = null,
+                infoMessage = buildDiscoverySuccessMessage(
+                    analysis = analysis,
+                    upgradeNotice = upgradeNotice,
+                ),
+                errorMessage = null,
+            )
+        }
+    }
+
     private fun buildAnalyzeSuccessMessage(
         info: VideoInfo,
         upgradeNotice: String?,
         isLoadingFormats: Boolean,
     ): String {
         val status = when {
-            isLoadingFormats -> "Link ready. Loading formats..."
+            isLoadingFormats -> "Loading download options..."
             info.isPlaylist -> {
                 val itemCount = info.playlistCount ?: info.playlistEntries.size
-                if (info.formats.isEmpty()) {
+                val hasLoadedPlaylistFormats = info.formats.isNotEmpty() ||
+                    info.playlistEntries.any { it.formats.isNotEmpty() }
+                if (!hasLoadedPlaylistFormats) {
                     "Playlist ready: $itemCount items found. Formats will resolve automatically when you queue selected items."
                 } else {
-                    "Playlist ready: $itemCount items will queue one by one."
+                    "Playlist ready: $itemCount items are ready to configure."
                 }
             }
             else -> "Found ${info.formats.size} formats."
@@ -2079,6 +2218,8 @@ class FormatViewModel @Inject constructor(
         info: VideoInfo,
         upgradeNotice: String?,
         keepLoadingFormats: Boolean,
+        selectedBrowseUrl: String,
+        openOptionsOnReady: Boolean,
     ) {
         val choiceBundle = buildChoices(info)
         val currentState = uiState.value
@@ -2113,6 +2254,7 @@ class FormatViewModel @Inject constructor(
             state.copy(
                 isAnalyzing = false,
                 isLoadingFormats = keepLoadingFormats,
+                shouldOpenOptionsSheet = openOptionsOnReady && !keepLoadingFormats,
                 messageScope = FormatMessageScope.BROWSER,
                 linkAnalysis = analysis,
                 videoInfo = info,
@@ -2123,7 +2265,7 @@ class FormatViewModel @Inject constructor(
                 selectedStreamType = resolvedStreamType,
                 selectedOutputTransform = resolvedOutputTransform,
                 selectedFormatSelector = selectedSelector,
-                selectedBrowseItemUrl = analysis.primaryItem?.webpageUrl ?: info.webpageUrl,
+                selectedBrowseItemUrl = selectedBrowseUrl,
                 customFileName = if (state.videoInfo?.webpageUrl == info.webpageUrl && state.customFileName.isNotBlank()) {
                     state.customFileName
                 } else {
@@ -2145,17 +2287,33 @@ class FormatViewModel @Inject constructor(
         }
     }
 
-    private fun loadFormatsForDiscoveredLink(
+    private suspend fun prepareDownloadOptionsForAnalysis(
         analysis: LinkAnalysisResult,
-        secureUrl: String,
+        selectionUrl: String,
         runtimeCookiesPath: String?,
         upgradeNotice: String?,
+        openOptionsOnReady: Boolean,
     ) {
-        val sourceUrl = analysis.primaryItem?.webpageUrl ?: analysis.webpageUrl ?: secureUrl
-        viewModelScope.launch {
-            val result = runCatching {
-                repository.loadFormats(
-                    url = sourceUrl,
+        _uiState.update { state ->
+            state.copy(
+                isAnalyzing = false,
+                isLoadingFormats = true,
+                shouldOpenOptionsSheet = false,
+                selectedBrowseItemUrl = selectionUrl,
+                messageScope = FormatMessageScope.BROWSER,
+                errorMessage = null,
+                infoMessage = if (analysis.isCollection) {
+                    "Loading collection download options..."
+                } else {
+                    "Loading download options..."
+                },
+            )
+        }
+
+        val result = if (analysis.isCollection) {
+            runCatching {
+                repository.loadFormatsForItems(
+                    urls = analysis.items.map { it.webpageUrl },
                     cookiesPath = runtimeCookiesPath,
                     userAgent = if (uiState.value.cookiesEnabled && uiState.value.cookieUserAgentEnabled) {
                         CookieTextCodec.COOKIE_USER_AGENT
@@ -2165,45 +2323,66 @@ class FormatViewModel @Inject constructor(
                 )
             }.getOrElse { throwable ->
                 Result.failure(IllegalStateException(throwable.message ?: "Format loading failed", throwable))
+            }.map { loadResults ->
+                analysis.withLoadedFormats(loadResults)
             }
-            result.fold(
-                onSuccess = { loadResult ->
-                    val current = uiState.value
-                    if (current.selectedBrowseItemUrl != sourceUrl && current.videoInfo?.webpageUrl != sourceUrl) {
-                        return@fold
-                    }
-                    val updatedAnalysis = analysis.withLoadedFormats(loadResult)
-                    val updatedInfo = updatedAnalysis.toLegacyVideoInfo()
-                    applyAnalyzedInfo(
-                        analysis = updatedAnalysis,
-                        info = updatedInfo,
-                        upgradeNotice = upgradeNotice,
-                        keepLoadingFormats = false,
-                    )
-                    persistReadyRecordIfNeeded(updatedInfo)
-                },
-                onFailure = { error ->
-                    logger.e("FormatViewModel", "Background format load failed for URL: $sourceUrl", error)
-                    val baseMessage = error.message?.takeIf { it.isNotBlank() } ?: "Unable to load formats right now."
-                    _uiState.update { state ->
-                        if (state.selectedBrowseItemUrl != sourceUrl && state.videoInfo?.webpageUrl != sourceUrl) {
-                            state
-                        } else {
-                            state.copy(
-                                isLoadingFormats = false,
-                                messageScope = FormatMessageScope.BROWSER,
-                                errorMessage = buildString {
-                                    append(baseMessage)
-                                    if (shouldShowRuntimeHint(baseMessage)) {
-                                        append(" Ensure yt-dlp runtime is initialized and this device ABI is supported.")
-                                    }
-                                },
-                            )
-                        }
-                    }
-                },
-            )
+        } else {
+            runCatching {
+                repository.loadFormats(
+                    url = selectionUrl,
+                    cookiesPath = runtimeCookiesPath,
+                    userAgent = if (uiState.value.cookiesEnabled && uiState.value.cookieUserAgentEnabled) {
+                        CookieTextCodec.COOKIE_USER_AGENT
+                    } else {
+                        null
+                    },
+                )
+            }.getOrElse { throwable ->
+                Result.failure(IllegalStateException(throwable.message ?: "Format loading failed", throwable))
+            }.map { loadResult ->
+                analysis.withLoadedFormats(loadResult)
+            }
         }
+
+        result.fold(
+            onSuccess = { updatedAnalysis ->
+                val current = uiState.value
+                if (current.selectedBrowseItemUrl != selectionUrl) {
+                    return@fold
+                }
+                val updatedInfo = updatedAnalysis.toLegacyVideoInfo()
+                applyAnalyzedInfo(
+                    analysis = updatedAnalysis,
+                    info = updatedInfo,
+                    upgradeNotice = upgradeNotice,
+                    keepLoadingFormats = false,
+                    selectedBrowseUrl = selectionUrl,
+                    openOptionsOnReady = openOptionsOnReady,
+                )
+                persistReadyRecordIfNeeded(updatedInfo)
+            },
+            onFailure = { error ->
+                logger.e("FormatViewModel", "Format load failed for selection: $selectionUrl", error)
+                val baseMessage = error.message?.takeIf { it.isNotBlank() } ?: "Unable to load formats right now."
+                _uiState.update { state ->
+                    if (state.selectedBrowseItemUrl != selectionUrl) {
+                        state
+                    } else {
+                        state.copy(
+                            isLoadingFormats = false,
+                            shouldOpenOptionsSheet = false,
+                            messageScope = FormatMessageScope.BROWSER,
+                            errorMessage = buildString {
+                                append(baseMessage)
+                                if (shouldShowRuntimeHint(baseMessage)) {
+                                    append(" Ensure yt-dlp runtime is initialized and this device ABI is supported.")
+                                }
+                            },
+                        )
+                    }
+                }
+            },
+        )
     }
 
     private fun buildPlaylistItemStates(

--- a/app/src/main/java/com/localdownloader/viewmodel/FormatViewModel.kt
+++ b/app/src/main/java/com/localdownloader/viewmodel/FormatViewModel.kt
@@ -16,7 +16,9 @@ import com.localdownloader.domain.models.ContrastMode
 import com.localdownloader.domain.models.CookieProfile
 import com.localdownloader.domain.models.DownloadOptions
 import com.localdownloader.domain.models.FormatChoice
+import com.localdownloader.domain.models.FormatLoadResult
 import com.localdownloader.domain.models.LinkAnalysisResult
+import com.localdownloader.domain.models.LinkSourceKind
 import com.localdownloader.domain.models.MediaFormat
 import com.localdownloader.domain.models.OutputTransform
 import com.localdownloader.domain.models.PlaylistDownloadRequest
@@ -236,80 +238,29 @@ class FormatViewModel @Inject constructor(
             }
                 .getOrElse { throwable ->
                     Result.failure(IllegalStateException(throwable.message ?: "Analyze failed", throwable))
-                }
+            }
             result.fold(
                 onSuccess = { analysis ->
                     val info = analysis.toLegacyVideoInfo()
-                    logger.i(
-                        "FormatViewModel",
-                        "Analyze success for URL: $secureUrl, title='${info.title}', formats=${info.formats.size}",
+                    logger.i("FormatViewModel", "Analyze success for URL: $secureUrl, title='${info.title}', formats=${info.formats.size}")
+                    val shouldLoadFormatsInBackground =
+                        analysis.sourceKind == LinkSourceKind.SINGLE_VIDEO && info.formats.isEmpty()
+                    applyAnalyzedInfo(
+                        analysis = analysis,
+                        info = info,
+                        upgradeNotice = upgradeNotice,
+                        keepLoadingFormats = shouldLoadFormatsInBackground,
                     )
-                    val choiceBundle = buildChoices(info)
-                    val resolvedStreamType = resolveAvailableStreamType(
-                        preferredStreamType = uiState.value.selectedStreamType,
-                        videoAudioChoices = choiceBundle.videoAudioChoices,
-                        videoOnlyChoices = choiceBundle.videoOnlyChoices,
-                        audioOnlyChoices = choiceBundle.audioOnlyChoices,
-                    )
-                    val resolvedOutputTransform = resolveAvailableOutputTransform(
-                        preferredTransform = OutputTransform.NONE,
-                        sourceStreamType = resolvedStreamType,
-                        videoAudioChoices = choiceBundle.videoAudioChoices,
-                        videoOnlyChoices = choiceBundle.videoOnlyChoices,
-                        audioOnlyChoices = choiceBundle.audioOnlyChoices,
-                    )
-                    val selectedSelector = firstSelectorForStreamType(
-                        streamType = resolvedStreamType,
-                        container = uiState.value.selectedContainer,
-                        videoAudioChoices = choiceBundle.videoAudioChoices,
-                        videoOnlyChoices = choiceBundle.videoOnlyChoices,
-                        audioOnlyChoices = choiceBundle.audioOnlyChoices,
-                    )
-                    _uiState.update { state ->
-                        val playlistItems = buildPlaylistItemStates(
-                            info = info,
-                            streamType = resolvedStreamType,
-                            container = state.selectedContainer,
-                            audioFormat = state.selectedAudioFormat,
-                            audioBitrateKbps = state.audioBitrateKbps,
+                    if (shouldLoadFormatsInBackground) {
+                        loadFormatsForDiscoveredLink(
+                            analysis = analysis,
+                            secureUrl = secureUrl,
+                            runtimeCookiesPath = runtimeCookiesPath,
+                            upgradeNotice = upgradeNotice,
                         )
-                        state.copy(
-                            isAnalyzing = false,
-                            messageScope = FormatMessageScope.BROWSER,
-                            linkAnalysis = analysis,
-                            videoInfo = info,
-                            availableVideoAudioChoices = choiceBundle.videoAudioChoices,
-                            availableVideoOnlyChoices = choiceBundle.videoOnlyChoices,
-                            availableAudioOnlyChoices = choiceBundle.audioOnlyChoices,
-                            playlistItems = playlistItems,
-                            selectedStreamType = resolvedStreamType,
-                            selectedOutputTransform = resolvedOutputTransform,
-                            selectedFormatSelector = selectedSelector,
-                            selectedBrowseItemUrl = analysis.primaryItem?.webpageUrl ?: info.webpageUrl,
-                            customFileName = info.title,
-                            enablePlaylist = state.enablePlaylist || info.isPlaylist,
-                            readyAnalyzedItems = upsertReadyRecord(
-                                state.readyAnalyzedItems,
-                                buildReadyRecord(info),
-                            ),
-                            restoringReadyItemUrl = null,
-                            infoMessage = listOfNotNull(
-                                upgradeNotice,
-                                when {
-                                    info.isPlaylist -> {
-                                        val itemCount = info.playlistCount ?: info.playlistEntries.size
-                                        if (info.formats.isEmpty()) {
-                                            "Playlist ready: $itemCount items found. Formats will resolve automatically when you queue selected items."
-                                        } else {
-                                            "Playlist ready: $itemCount items will queue one by one."
-                                        }
-                                    }
-                                    else -> "Found ${info.formats.size} formats."
-                                },
-                            ).joinToString(" "),
-                        )
+                    } else {
+                        persistReadyRecordIfNeeded(info)
                     }
-                    persistReadyRecordIfNeeded(info)
                 },
                 onFailure = { error ->
                     logger.e("FormatViewModel", "Analyze failed for URL: $secureUrl", error)
@@ -317,6 +268,7 @@ class FormatViewModel @Inject constructor(
                     _uiState.update { state ->
                         state.copy(
                             isAnalyzing = false,
+                            isLoadingFormats = false,
                             messageScope = FormatMessageScope.BROWSER,
                             errorMessage = buildString {
                                 append(baseMessage)
@@ -1819,7 +1771,7 @@ class FormatViewModel @Inject constructor(
      */
     fun isDownloadButtonEnabled(): Boolean {
         val state = uiState.value
-        if (state.isQueueing) return false
+        if (state.isQueueing || state.isLoadingFormats) return false
         
         if (state.isDownloadButtonDisabled) {
             val elapsed = System.currentTimeMillis() - state.downloadButtonDisabledAt
@@ -2066,6 +2018,191 @@ class FormatViewModel @Inject constructor(
             playlistCount = playlistCount ?: items.size.takeIf { isCollection },
             playlistEntries = playlistEntries,
         )
+    }
+
+    private fun LinkAnalysisResult.withLoadedFormats(result: FormatLoadResult): LinkAnalysisResult {
+        val targetUrl = result.webpageUrl
+        val updatedItems = items.map { item ->
+            if (item.webpageUrl == targetUrl) {
+                item.copy(
+                    title = result.title.ifBlank { item.title },
+                    formats = result.formats,
+                    extractorArgs = result.extractorArgs ?: item.extractorArgs,
+                    infoJsonPath = result.infoJsonPath ?: item.infoJsonPath,
+                )
+            } else {
+                item
+            }
+        }
+        val primaryUpdated = updatedItems.firstOrNull { it.webpageUrl == targetUrl }
+        return copy(
+            title = if (sourceKind == LinkSourceKind.SINGLE_VIDEO && result.title.isNotBlank()) result.title else title,
+            rootFormats = if (sourceKind == LinkSourceKind.SINGLE_VIDEO) result.formats else rootFormats,
+            extractorArgs = result.extractorArgs ?: extractorArgs,
+            infoJsonPath = result.infoJsonPath ?: infoJsonPath,
+            items = updatedItems.ifEmpty {
+                listOfNotNull(
+                    primaryUpdated ?: primaryItem?.copy(
+                        title = result.title.ifBlank { primaryItem.title },
+                        formats = result.formats,
+                        extractorArgs = result.extractorArgs ?: primaryItem.extractorArgs,
+                        infoJsonPath = result.infoJsonPath ?: primaryItem.infoJsonPath,
+                    ),
+                )
+            },
+        )
+    }
+
+    private fun buildAnalyzeSuccessMessage(
+        info: VideoInfo,
+        upgradeNotice: String?,
+        isLoadingFormats: Boolean,
+    ): String {
+        val status = when {
+            isLoadingFormats -> "Link ready. Loading formats..."
+            info.isPlaylist -> {
+                val itemCount = info.playlistCount ?: info.playlistEntries.size
+                if (info.formats.isEmpty()) {
+                    "Playlist ready: $itemCount items found. Formats will resolve automatically when you queue selected items."
+                } else {
+                    "Playlist ready: $itemCount items will queue one by one."
+                }
+            }
+            else -> "Found ${info.formats.size} formats."
+        }
+        return listOfNotNull(upgradeNotice, status).joinToString(" ")
+    }
+
+    private fun applyAnalyzedInfo(
+        analysis: LinkAnalysisResult,
+        info: VideoInfo,
+        upgradeNotice: String?,
+        keepLoadingFormats: Boolean,
+    ) {
+        val choiceBundle = buildChoices(info)
+        val currentState = uiState.value
+        val resolvedStreamType = resolveAvailableStreamType(
+            preferredStreamType = currentState.selectedStreamType,
+            videoAudioChoices = choiceBundle.videoAudioChoices,
+            videoOnlyChoices = choiceBundle.videoOnlyChoices,
+            audioOnlyChoices = choiceBundle.audioOnlyChoices,
+        )
+        val resolvedOutputTransform = resolveAvailableOutputTransform(
+            preferredTransform = OutputTransform.NONE,
+            sourceStreamType = resolvedStreamType,
+            videoAudioChoices = choiceBundle.videoAudioChoices,
+            videoOnlyChoices = choiceBundle.videoOnlyChoices,
+            audioOnlyChoices = choiceBundle.audioOnlyChoices,
+        )
+        val selectedSelector = firstSelectorForStreamType(
+            streamType = resolvedStreamType,
+            container = currentState.selectedContainer,
+            videoAudioChoices = choiceBundle.videoAudioChoices,
+            videoOnlyChoices = choiceBundle.videoOnlyChoices,
+            audioOnlyChoices = choiceBundle.audioOnlyChoices,
+        )
+        _uiState.update { state ->
+            val playlistItems = buildPlaylistItemStates(
+                info = info,
+                streamType = resolvedStreamType,
+                container = state.selectedContainer,
+                audioFormat = state.selectedAudioFormat,
+                audioBitrateKbps = state.audioBitrateKbps,
+            )
+            state.copy(
+                isAnalyzing = false,
+                isLoadingFormats = keepLoadingFormats,
+                messageScope = FormatMessageScope.BROWSER,
+                linkAnalysis = analysis,
+                videoInfo = info,
+                availableVideoAudioChoices = choiceBundle.videoAudioChoices,
+                availableVideoOnlyChoices = choiceBundle.videoOnlyChoices,
+                availableAudioOnlyChoices = choiceBundle.audioOnlyChoices,
+                playlistItems = playlistItems,
+                selectedStreamType = resolvedStreamType,
+                selectedOutputTransform = resolvedOutputTransform,
+                selectedFormatSelector = selectedSelector,
+                selectedBrowseItemUrl = analysis.primaryItem?.webpageUrl ?: info.webpageUrl,
+                customFileName = if (state.videoInfo?.webpageUrl == info.webpageUrl && state.customFileName.isNotBlank()) {
+                    state.customFileName
+                } else {
+                    info.title
+                },
+                enablePlaylist = state.enablePlaylist || info.isPlaylist,
+                readyAnalyzedItems = upsertReadyRecord(
+                    state.readyAnalyzedItems,
+                    buildReadyRecord(info),
+                ),
+                restoringReadyItemUrl = null,
+                infoMessage = buildAnalyzeSuccessMessage(
+                    info = info,
+                    upgradeNotice = upgradeNotice,
+                    isLoadingFormats = keepLoadingFormats,
+                ),
+                errorMessage = null,
+            )
+        }
+    }
+
+    private fun loadFormatsForDiscoveredLink(
+        analysis: LinkAnalysisResult,
+        secureUrl: String,
+        runtimeCookiesPath: String?,
+        upgradeNotice: String?,
+    ) {
+        val sourceUrl = analysis.primaryItem?.webpageUrl ?: analysis.webpageUrl ?: secureUrl
+        viewModelScope.launch {
+            val result = runCatching {
+                repository.loadFormats(
+                    url = sourceUrl,
+                    cookiesPath = runtimeCookiesPath,
+                    userAgent = if (uiState.value.cookiesEnabled && uiState.value.cookieUserAgentEnabled) {
+                        CookieTextCodec.COOKIE_USER_AGENT
+                    } else {
+                        null
+                    },
+                )
+            }.getOrElse { throwable ->
+                Result.failure(IllegalStateException(throwable.message ?: "Format loading failed", throwable))
+            }
+            result.fold(
+                onSuccess = { loadResult ->
+                    val current = uiState.value
+                    if (current.selectedBrowseItemUrl != sourceUrl && current.videoInfo?.webpageUrl != sourceUrl) {
+                        return@fold
+                    }
+                    val updatedAnalysis = analysis.withLoadedFormats(loadResult)
+                    val updatedInfo = updatedAnalysis.toLegacyVideoInfo()
+                    applyAnalyzedInfo(
+                        analysis = updatedAnalysis,
+                        info = updatedInfo,
+                        upgradeNotice = upgradeNotice,
+                        keepLoadingFormats = false,
+                    )
+                    persistReadyRecordIfNeeded(updatedInfo)
+                },
+                onFailure = { error ->
+                    logger.e("FormatViewModel", "Background format load failed for URL: $sourceUrl", error)
+                    val baseMessage = error.message?.takeIf { it.isNotBlank() } ?: "Unable to load formats right now."
+                    _uiState.update { state ->
+                        if (state.selectedBrowseItemUrl != sourceUrl && state.videoInfo?.webpageUrl != sourceUrl) {
+                            state
+                        } else {
+                            state.copy(
+                                isLoadingFormats = false,
+                                messageScope = FormatMessageScope.BROWSER,
+                                errorMessage = buildString {
+                                    append(baseMessage)
+                                    if (shouldShowRuntimeHint(baseMessage)) {
+                                        append(" Ensure yt-dlp runtime is initialized and this device ABI is supported.")
+                                    }
+                                },
+                            )
+                        }
+                    }
+                },
+            )
+        }
     }
 
     private fun buildPlaylistItemStates(

--- a/app/src/main/java/com/localdownloader/viewmodel/FormatViewModel.kt
+++ b/app/src/main/java/com/localdownloader/viewmodel/FormatViewModel.kt
@@ -17,6 +17,7 @@ import com.localdownloader.domain.models.CookieProfile
 import com.localdownloader.domain.models.DownloadOptions
 import com.localdownloader.domain.models.FormatChoice
 import com.localdownloader.domain.models.FormatLoadResult
+import com.localdownloader.domain.models.LinkAnalysisItem
 import com.localdownloader.domain.models.LinkAnalysisResult
 import com.localdownloader.domain.models.LinkSourceKind
 import com.localdownloader.domain.models.MediaFormat

--- a/docs/new-link-analyzer-migration-plan.md
+++ b/docs/new-link-analyzer-migration-plan.md
@@ -1,0 +1,321 @@
+# New Link Analyzer Migration Plan
+
+## Goal
+
+Migrate the app from the current "analyze one URL into one `VideoInfo`" flow to a
+discovery-first flow that separates:
+
+1. link discovery
+2. format loading
+3. queue building
+
+The target is to keep our current Compose UI, worker stack, typed models, and
+download reliability while adopting a more flexible analysis behavior.
+
+## What We Are Migrating
+
+We want the following behaviors:
+
+- source-aware link classification
+- lightweight playlist and channel discovery
+- incremental item loading
+- deferred format loading
+- refreshable per-item or multi-item format retrieval
+- format-view modes such as `All`, `Suggested`, `Smallest`, and generic fallback
+
+We do not want to directly port:
+
+- `ResultItem`
+- `DownloadItem`
+- Fragment or RecyclerView UI
+- text-heavy `format_note` parsing as the primary source of truth
+
+Our migration should keep structured models and typed selection logic centered
+around `MediaFormat`, `FormatChoice`, and Compose state.
+
+## Current Flow
+
+Current path:
+
+- `FormatViewModel.analyzeUrlInternal`
+- `DownloadRepositoryImpl.analyzeUrl`
+- `FormatExtractor.analyze`
+- `VideoInfo`
+- `buildChoiceBundle`
+- `BrowserScreen` bottom sheet
+
+This path assumes that link discovery and format loading happen together.
+
+## Target Flow
+
+Target path:
+
+1. UI submits a URL.
+2. ViewModel asks repository for source analysis.
+3. Repository returns a lightweight source result:
+   - single item
+   - playlist
+   - channel feed
+   - generic URL
+4. UI renders discovered items immediately.
+5. Formats are loaded only when needed:
+   - current item
+   - selected playlist items
+   - manual refresh
+6. Existing queue logic converts chosen formats into `DownloadOptions`.
+
+## New Domain Models
+
+Add these new models under `app/src/main/java/com/localdownloader/domain/models`:
+
+- `LinkAnalysisResult.kt`
+  - root response for discovery
+  - contains URL metadata, source kind, title, thumbnail, item count, and items
+- `LinkAnalysisItem.kt`
+  - one discovered playable item
+  - id, title, webpageUrl, uploader, duration, thumbnail, playlist metadata
+  - optional lightweight `formats` list if discovery already includes them
+- `LinkSourceKind.kt`
+  - `SINGLE_VIDEO`
+  - `PLAYLIST`
+  - `CHANNEL`
+  - `GENERIC_URL`
+- `FormatLoadRequest.kt`
+  - one item or many items to load formats for
+- `FormatLoadResult.kt`
+  - item URL/id plus resolved `List<MediaFormat>`
+- `FormatViewMode.kt`
+  - `ALL`
+  - `SUGGESTED`
+  - `SMALLEST`
+  - `GENERIC`
+
+Keep `VideoInfo.kt` during migration for download execution compatibility. Do not
+delete it until queue building no longer depends on it.
+
+## Repository Contract Changes
+
+Update `domain/repositories/DownloaderRepository.kt` conceptually with new APIs:
+
+- keep existing:
+  - `suspend fun analyzeUrl(...)`
+- add:
+  - `suspend fun analyzeLink(url: String, cookiesPath: String?, userAgent: String?): Result<LinkAnalysisResult>`
+  - `suspend fun loadFormats(url: String, cookiesPath: String?, userAgent: String?): Result<List<MediaFormat>>`
+  - `suspend fun loadFormatsForItems(urls: List<String>, ...): Result<List<FormatLoadResult>>`
+
+Implementation lives in:
+
+- `app/src/main/java/com/localdownloader/data/DownloadRepositoryImpl.kt`
+
+Migration note:
+
+- `analyzeUrl` can temporarily delegate to `analyzeLink` plus `loadFormats` for
+  single-item legacy callers.
+
+## Downloader Layer Changes
+
+Split `FormatExtractor.kt` responsibilities into discovery and format loading.
+
+Recommended new files in `app/src/main/java/com/localdownloader/downloader`:
+
+- `LinkAnalyzer.kt`
+  - classifies input
+  - runs lightweight source discovery
+  - supports fast playlist/channel analysis
+  - returns `LinkAnalysisResult`
+- `FormatLoader.kt`
+  - loads formats for one item
+  - supports cached info-json reuse
+  - supports bulk multi-item loading
+  - returns typed `MediaFormat`
+- `LinkSourceClassifier.kt`
+  - central URL classification rules
+- `LinkAnalysisMapper.kt`
+  - maps yt-dlp JSON into `LinkAnalysisResult` and `LinkAnalysisItem`
+
+Keep `FormatExtractor.kt` initially, but reduce it to a compatibility adapter:
+
+- `analyze()` can call `LinkAnalyzer + FormatLoader` during migration
+- existing queue/download callers stay stable while the new browse flow lands
+
+## ViewModel Changes
+
+Primary file:
+
+- `viewmodel/FormatViewModel.kt`
+
+Recommended state changes in:
+
+- `app/src/main/java/com/localdownloader/viewmodel/FormatUiState.kt`
+
+Add fields such as:
+
+- `linkAnalysis: LinkAnalysisResult?`
+- `discoveredItems: List<LinkAnalysisItemUiState>`
+- `selectedBrowseItemUrl: String?`
+- `isLoadingFormats: Boolean`
+- `formatViewMode: FormatViewMode`
+- `formatSourceSummary: String?`
+
+Add a new UI state model:
+
+- `DiscoveredItemUiState.kt`
+  - item metadata
+  - selection flags
+  - expansion flags
+  - loaded formats
+  - available format choices
+  - loading/error state
+
+Migration behavior for `FormatViewModel`:
+
+1. `analyzeUrl()` becomes discovery-first.
+2. For single links:
+   - auto-load formats after discovery.
+3. For playlists/channels:
+   - show discovered items immediately.
+   - load formats only for:
+     - selected items
+     - opened item
+     - explicit refresh
+4. Build `FormatChoice` lists from loaded `MediaFormat`, not from raw text labels.
+
+## UI Changes
+
+Primary file:
+
+- `app/src/main/java/com/localdownloader/ui/screens/BrowserScreen.kt`
+
+Target UI structure:
+
+- top card remains the URL entry point
+- results area becomes a discovery list instead of only "analyzed one item"
+- single item:
+  - current options sheet can remain
+- playlist/channel:
+  - show discovered items first
+  - allow batch selection
+  - add "Load formats" and "Refresh formats"
+  - allow global format mode/filter controls
+
+Recommended new Compose components:
+
+- `BrowseDiscoveryCard`
+- `BrowseDiscoveryList`
+- `BrowseItemCard`
+- `FormatModeChipRow`
+- `LoadFormatsActionBar`
+
+Do not port an older bottom-sheet UI literally. Rebuild the same
+behavior in Compose.
+
+## Format View Strategy
+
+Keep our typed format model and add view modes on top of it.
+
+Implement in `FormatViewModel` or a helper such as:
+
+- `viewmodel/FormatPresentationBuilder.kt`
+
+Responsibilities:
+
+- `ALL`
+  - every valid typed format
+- `SUGGESTED`
+  - keep current quality-aware grouped choices
+- `SMALLEST`
+  - smallest option per effective quality bucket
+- `GENERIC`
+  - synthetic fallback choices like current "auto/mp4/mp3" style outputs
+
+Important:
+
+- do not drive filtering from `format_note.contains("audio")`
+- use structured fields such as `vcodec`, `acodec`, `resolution`, `bitrateKbps`,
+  `fileSizeBytes`, and `isVideoOnly`
+
+## Queue Compatibility
+
+Queue building should stay compatible during migration.
+
+Keep these files stable as long as possible:
+
+- `viewmodel/FormatViewModel.kt`
+- `domain/models/DownloadOptions.kt`
+- `worker/DownloadWorker.kt`
+
+Bridge strategy:
+
+- selected `LinkAnalysisItem` + loaded `MediaFormat` + chosen `FormatChoice`
+  should still produce the same `DownloadOptions`
+- reuse `infoJsonPath` when available for single-item downloads
+- for playlist items, use per-item URL queueing with current worker behavior
+
+## Phased Implementation
+
+### Phase 1
+
+- add new domain models
+- add `LinkSourceClassifier`
+- add `LinkAnalyzer`
+- add `FormatLoader`
+- keep current UI untouched
+- make `FormatExtractor` delegate internally where practical
+
+### Phase 2
+
+- update `DownloadRepositoryImpl`
+- add new repository methods
+- let `FormatViewModel` run discovery-first internally
+- preserve current single-video UX
+
+### Phase 3
+
+- extend `FormatUiState`
+- add discovered item state
+- update `BrowserScreen` to render discovery results for playlists/channels
+
+### Phase 4
+
+- add format view modes
+- add lazy format loading actions
+- support multi-item format refresh
+
+### Phase 5
+
+- remove old one-shot assumptions from `FormatViewModel`
+- trim or retire legacy `VideoInfo` browse usage
+- keep `VideoInfo` only if download execution still benefits from it
+
+## Recommended First Code Slice
+
+The safest first implementation slice is:
+
+1. add `LinkSourceKind`, `LinkAnalysisResult`, `LinkAnalysisItem`
+2. extract URL classification into `LinkSourceClassifier`
+3. create `LinkAnalyzer` using the current `FormatExtractor` parsing logic
+4. add `loadFormats(url)` beside current `analyze()`
+5. make `FormatViewModel.analyzeUrlInternal()` branch on source kind
+
+That gives us a real migration start without rewriting the entire browse screen
+in one shot.
+
+## Risks
+
+- queue code currently assumes analysis and format selection happen together
+- playlist item state is currently derived from `VideoInfo.playlistEntries`
+- browse UI currently expects one active `videoInfo`
+- a literal port from an older app would weaken model quality by relying more on raw
+  text parsing and less on typed fields
+
+## Recommendation
+
+Proceed with a staged migration, not a rewrite.
+
+The best end state is:
+
+- discovery-first analysis behavior
+- our current typed models and downloader reliability
+- Compose-native browse and format UI
+- compatibility preserved for worker/download execution throughout the rollout


### PR DESCRIPTION
## Summary

This PR lays the groundwork for migrating the current one-shot link analysis flow to a discovery-first structure.

Instead of treating analysis as only `URL -> VideoInfo`, this starts splitting the flow into:

1. link discovery
2. format loading
3. queue building

The current browse and queue pipeline is still kept compatible by bridging the new discovery result back into the existing `VideoInfo` shape where needed.

## What changed

- Added new typed discovery models:
  - `LinkSourceKind`
  - `LinkAnalysisItem`
  - `LinkAnalysisResult`
  - `FormatLoadRequest`
  - `FormatLoadResult`
  - `FormatViewMode`
- Added `LinkSourceClassifier` for centralized URL-based source classification
- Extended `DownloaderRepository` with:
  - `analyzeLink(...)`
  - `loadFormats(...)`
  - `loadFormatsForItems(...)`
- Updated `DownloadRepositoryImpl` to implement the new discovery/format-loading APIs
- Extended `FormatExtractor` with:
  - discovery-first link analysis
  - standalone format loading
  - shared analyzer candidate resolution
- Updated `FormatUiState` with new migration state:
  - `linkAnalysis`
  - `selectedBrowseItemUrl`
  - `isLoadingFormats`
  - `formatViewMode`
- Updated `FormatViewModel` to use `analyzeLink(...)` in the active browse path while preserving existing `VideoInfo`-based behavior through a compatibility bridge
- Added migration planning doc:
  - `docs/new-link-analyzer-migration-plan.md`

## Important behavior notes

- Existing queue/download flow is intentionally preserved for now
- Batch format loading was adjusted so one failed item does not abort the whole batch
- Collection/root metadata is preserved in the legacy `VideoInfo` bridge instead of being replaced by the first item
- Source classification currently matches the app’s existing link-only browse flow

## What this PR does not do yet

- It does not fully replace the current browse UI with discovery-first item rendering
- It does not yet expose per-item lazy format loading in the screen
- It does not yet add the full format presentation modes in the UI
- It does not remove legacy `VideoInfo` usage yet

## Follow-up work

- Render discovered playlist/channel items directly in `BrowserScreen`
- Load formats lazily for selected or opened items
- Introduce format view modes in the UI
- Reduce and eventually remove legacy one-shot browse assumptions

## Verification

Build verification could not be completed on this machine because Android SDK configuration is missing for the repo (`ANDROID_HOME` / `sdk.dir` not set).  
So this PR is reviewed and pushed as a migration foundation, but not fully compile-verified locally yet.