### PR TITLE
fix(security): encrypt download-option secrets sidecar at rest

### DIFF
--- a/app/src/main/java/com/localdownloader/data/DownloadOptionSecretsStore.kt
+++ b/app/src/main/java/com/localdownloader/data/DownloadOptionSecretsStore.kt
@@ -17,6 +17,7 @@ class DownloadOptionSecretsStore @Inject constructor(
     @ApplicationContext private val context: Context,
     private val json: Json,
     private val logger: Logger,
+    private val secretsCipher: SecretsCipher,
 ) {
 
     fun persist(taskId: String, options: DownloadOptions): String {
@@ -101,7 +102,17 @@ class DownloadOptionSecretsStore @Inject constructor(
         val target = secretsFile(taskId)
         target.parentFile?.mkdirs()
         val tempFile = File(target.parentFile, "${target.name}.tmp")
-        tempFile.writeText(json.encodeToString(secrets))
+        val plaintext = json.encodeToString(secrets).toByteArray(Charsets.UTF_8)
+        val encrypted = runCatching { secretsCipher.encrypt(plaintext) }
+            .getOrElse { error ->
+                logger.w(
+                    "DownloadOptionSecretsStore",
+                    "Failed encrypting secrets for taskId=$taskId; aborting write",
+                    error,
+                )
+                return
+            }
+        tempFile.writeBytes(encrypted)
         if (!tempFile.renameTo(target)) {
             tempFile.copyTo(target, overwrite = true)
             tempFile.delete()
@@ -113,11 +124,38 @@ class DownloadOptionSecretsStore @Inject constructor(
         if (!secretFile.exists() || !secretFile.isFile) {
             return null
         }
+        val bytes = runCatching { secretFile.readBytes() }.getOrNull() ?: return null
+        val plaintext = decodeSecretsBytes(taskId, bytes) ?: return null
         return runCatching {
-            json.decodeFromString<PersistedDownloadOptionSecrets>(secretFile.readText())
+            json.decodeFromString<PersistedDownloadOptionSecrets>(
+                plaintext.toString(Charsets.UTF_8),
+            )
         }.onFailure { error ->
-            logger.w("DownloadOptionSecretsStore", "Failed reading persisted secrets for taskId=$taskId", error)
+            logger.w("DownloadOptionSecretsStore", "Failed decoding persisted secrets for taskId=$taskId", error)
         }.getOrNull()
+    }
+
+    /**
+     * Decrypts an encrypted sidecar, transparently falling back to plaintext for
+     * sidecars written by older app versions so existing tasks keep hydrating.
+     * Returns null if the payload can be neither decrypted nor parsed.
+     */
+    private fun decodeSecretsBytes(taskId: String, bytes: ByteArray): ByteArray? {
+        if (secretsCipher.isEncryptedBlob(bytes)) {
+            val decrypted = secretsCipher.decrypt(bytes)
+            if (decrypted == null) {
+                logger.w(
+                    "DownloadOptionSecretsStore",
+                    "Failed decrypting persisted secrets for taskId=$taskId",
+                )
+            }
+            return decrypted
+        }
+        logger.w(
+            "DownloadOptionSecretsStore",
+            "Legacy plaintext secrets sidecar for taskId=$taskId; will be re-encrypted on next persist",
+        )
+        return bytes
     }
 
     private fun secretsFile(taskId: String): File {

--- a/app/src/main/java/com/localdownloader/data/SecretsCipher.kt
+++ b/app/src/main/java/com/localdownloader/data/SecretsCipher.kt
@@ -1,0 +1,104 @@
+package com.localdownloader.data
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Encrypts/decrypts the download-option secrets sidecar at rest using AES-256-GCM
+ * backed by the Android Keystore, so that session cookies, PO tokens, user-agent
+ * headers and `youtubeDataSyncId` are never written to disk as plaintext.
+ *
+ * On-disk layout produced by [KeystoreSecretsCipher.encrypt]:
+ *   [MAGIC][12-byte IV][ciphertext + 16-byte GCM auth tag]
+ * The [SecretsCipherFormat] helpers own that layout so they can be unit-tested on
+ * the JVM without an Android Keystore.
+ */
+internal interface SecretsCipher {
+    fun encrypt(plaintext: ByteArray): ByteArray
+    fun decrypt(blob: ByteArray): ByteArray?
+    fun isEncryptedBlob(bytes: ByteArray): Boolean
+}
+
+internal object SecretsCipherFormat {
+    /** Leading byte that marks an encrypted (v1) sidecar. */
+    const val MAGIC: Byte = 0x01
+    const val IV_LENGTH = 12
+
+    fun isEncryptedBlob(bytes: ByteArray): Boolean =
+        bytes.size > IV_LENGTH + 1 && bytes[0] == MAGIC
+
+    fun formatBlob(iv: ByteArray, ciphertext: ByteArray): ByteArray =
+        ByteArray(1 + IV_LENGTH + ciphertext.size).also { out ->
+            out[0] = MAGIC
+            System.arraycopy(iv, 0, out, 1, IV_LENGTH)
+            System.arraycopy(ciphertext, 0, out, 1 + IV_LENGTH, ciphertext.size)
+        }
+
+    fun extractIvAndCiphertext(blob: ByteArray): Pair<ByteArray, ByteArray>? {
+        if (!isEncryptedBlob(blob)) return null
+        val iv = blob.copyOfRange(1, 1 + IV_LENGTH)
+        val ciphertext = blob.copyOfRange(1 + IV_LENGTH, blob.size)
+        return iv to ciphertext
+    }
+}
+
+@Singleton
+internal class KeystoreSecretsCipher @Inject constructor() : SecretsCipher {
+
+    private val secretKey: SecretKey by lazy { getOrCreateKey() }
+
+    override fun encrypt(plaintext: ByteArray): ByteArray {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey)
+        val iv = cipher.iv
+        val ciphertext = cipher.doFinal(plaintext)
+        return SecretsCipherFormat.formatBlob(iv, ciphertext)
+    }
+
+    override fun decrypt(blob: ByteArray): ByteArray? {
+        val (iv, ciphertext) = SecretsCipherFormat.extractIvAndCiphertext(blob) ?: return null
+        return runCatching {
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, GCMParameterSpec(TAG_LENGTH_BITS, iv))
+            cipher.doFinal(ciphertext)
+        }.getOrNull()
+    }
+
+    override fun isEncryptedBlob(bytes: ByteArray): Boolean =
+        SecretsCipherFormat.isEncryptedBlob(bytes)
+
+    private fun getOrCreateKey(): SecretKey {
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        keyStore.getKey(KEY_ALIAS, null)?.let { return it as SecretKey }
+
+        val keyGenerator = KeyGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_AES,
+            ANDROID_KEYSTORE,
+        )
+        keyGenerator.init(
+            KeyGenParameterSpec.Builder(
+                KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setKeySize(256)
+                .build(),
+        )
+        return keyGenerator.generateKey()
+    }
+
+    private companion object {
+        const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        const val KEY_ALIAS = "download_option_secrets_key"
+        const val TRANSFORMATION = "AES/GCM/NoPadding"
+        const val TAG_LENGTH_BITS = 128
+    }
+}

--- a/app/src/main/java/com/localdownloader/di/RepositoryModule.kt
+++ b/app/src/main/java/com/localdownloader/di/RepositoryModule.kt
@@ -1,6 +1,8 @@
 package com.localdownloader.di
 
 import com.localdownloader.data.DownloadRepositoryImpl
+import com.localdownloader.data.KeystoreSecretsCipher
+import com.localdownloader.data.SecretsCipher
 import com.localdownloader.domain.repositories.DownloaderRepository
 import dagger.Binds
 import dagger.Module
@@ -17,4 +19,10 @@ abstract class RepositoryModule {
     abstract fun bindDownloaderRepository(
         implementation: DownloadRepositoryImpl,
     ): DownloaderRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindSecretsCipher(
+        implementation: KeystoreSecretsCipher,
+    ): SecretsCipher
 }

--- a/app/src/test/java/com/localdownloader/data/SecretsCipherFormatTest.kt
+++ b/app/src/test/java/com/localdownloader/data/SecretsCipherFormatTest.kt
@@ -1,0 +1,99 @@
+package com.localdownloader.data
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SecretsCipherFormatTest {
+
+    @Test
+    fun isEncryptedBlob_recognizesMagicPrefixedBlob() {
+        val iv = ByteArray(SecretsCipherFormat.IV_LENGTH) { 1 }
+        val ciphertext = byteArrayOf(2, 3, 4, 5)
+        val blob = SecretsCipherFormat.formatBlob(iv, ciphertext)
+
+        assertTrue(SecretsCipherFormat.isEncryptedBlob(blob))
+    }
+
+    @Test
+    fun isEncryptedBlob_rejectsPlaintextJson() {
+        val plaintext = """{"youtubePoToken":"abc"}""".toByteArray()
+        assertFalse(SecretsCipherFormat.isEncryptedBlob(plaintext))
+    }
+
+    @Test
+    fun isEncryptedBlob_rejectsTooShortInput() {
+        assertFalse(SecretsCipherFormat.isEncryptedBlob(byteArrayOf(SecretsCipherFormat.MAGIC)))
+        assertFalse(SecretsCipherFormat.isEncryptedBlob(ByteArray(0)))
+    }
+
+    @Test
+    fun formatBlob_thenExtract_reconstructsIvAndCiphertext() {
+        val iv = ByteArray(SecretsCipherFormat.IV_LENGTH) { 0x42 }
+        val ciphertext = byteArrayOf(10, 20, 30, 40, 50)
+
+        val blob = SecretsCipherFormat.formatBlob(iv, ciphertext)
+        val (extractedIv, extractedCiphertext) = SecretsCipherFormat.extractIvAndCiphertext(blob)
+
+        assertNotNull(extractedIv)
+        assertContentEquals(iv, extractedIv)
+        assertContentEquals(ciphertext, extractedCiphertext)
+    }
+
+    @Test
+    fun extractIvAndCiphertext_returnsNullForPlaintext() {
+        val plaintext = """{"extractorArgs":"x"}""".toByteArray()
+        assertNull(SecretsCipherFormat.extractIvAndCiphertext(plaintext))
+    }
+
+    @Test
+    fun formatBlob_leadsWithMagicByte() {
+        val iv = ByteArray(SecretsCipherFormat.IV_LENGTH)
+        val blob = SecretsCipherFormat.formatBlob(iv, byteArrayOf(1))
+        assertEquals(SecretsCipherFormat.MAGIC, blob[0])
+    }
+
+    @Test
+    fun roundTrip_throughFakeCipher_preservesPlaintext() {
+        val cipher = FakeSecretsCipher()
+        val plaintext = """{"youtubePoToken":"secret-token"}""".toByteArray()
+
+        val encrypted = cipher.encrypt(plaintext)
+        assertTrue(cipher.isEncryptedBlob(encrypted))
+        assertFalse(encrypted.contentEquals(plaintext))
+
+        val decrypted = cipher.decrypt(encrypted)
+        assertNotNull(decrypted)
+        assertContentEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun decrypt_returnsNullForPlaintextInput() {
+        val cipher = FakeSecretsCipher()
+        val plaintext = """{"youtubeCookiesPath":"/c.txt"}""".toByteArray()
+        // A plaintext payload handed to decrypt() should fail closed, not return garbage.
+        assertNull(cipher.decrypt(plaintext))
+    }
+
+    private class FakeSecretsCipher : SecretsCipher {
+        override fun encrypt(plaintext: ByteArray): ByteArray {
+            // Invert every byte as a stand-in "cipher" so the output differs from plaintext
+            // but is reversible; wrap in the real on-disk format.
+            val transformed = plaintext.map { (it.toInt() xor 0xFF).toByte() }.toByteArray()
+            val iv = ByteArray(SecretsCipherFormat.IV_LENGTH) { 0x7A }
+            return SecretsCipherFormat.formatBlob(iv, transformed)
+        }
+
+        override fun decrypt(blob: ByteArray): ByteArray? {
+            val (iv, ciphertext) = SecretsCipherFormat.extractIvAndCiphertext(blob) ?: return null
+            return ciphertext.map { (it.toInt() xor 0xFF).toByte() }.toByteArray()
+        }
+
+        override fun isEncryptedBlob(bytes: ByteArray): Boolean =
+            SecretsCipherFormat.isEncryptedBlob(bytes)
+    }
+}


### PR DESCRIPTION
## Summary

`DownloadOptionSecretsStore` correctly separates secrets (cookies, PO tokens, user-agent headers, `youtubeDataSyncId`) from the main task JSON and writes them to a sidecar file under `noBackupFilesDir/task-option-secrets/<taskId>.json` — but it wrote that sidecar as **plaintext JSON**, unencrypted at rest. On a rooted device or via an `adb`/backup extraction on a debuggable build, the user's logged-in session credentials were trivially readable and replayable.

This PR encrypts the sidecar at rest with AES-256-GCM backed by the Android Keystore, while preserving the existing temp-file-then-rename atomic write, the task-id sanitization, and transparent backward compatibility with plaintext sidecars written by older app versions.

Fixes #90.

## Root cause

`writeSecrets()` called `tempFile.writeText(json.encodeToString(secrets))` — the secrets object (holding `extractorArgs`, `youtubeCookiesPath`, `youtubePoToken`, `youtubeDataSyncId`, `userAgentHeader`, …) was serialized straight to disk with no encryption. `readSecrets()` read it back with `secretFile.readText()`. Everything else in the store (the redaction discipline, the sidecar separation, the atomic write, the `SAFE_TASK_ID_REGEX` sanitization) was already correct — only the storage format was the gap.

## Changes

**`app/src/main/java/com/localdownloader/data/SecretsCipher.kt` (new)**
- `SecretsCipher` interface (`encrypt` / `decrypt` / `isEncryptedBlob`) so the store depends on an abstraction, not a concrete crypto class.
- `SecretsCipherFormat` — a pure, Android-free object owning the on-disk blob layout `[1-byte MAGIC][12-byte IV][ciphertext + 16-byte GCM auth tag]`. Splitting the format logic out keeps it unit-testable on the JVM without an Android Keystore.
- `KeystoreSecretsCipher` — AES-256-GCM via `javax.crypto` backed by an `AndroidKeyStore` key (`download_option_secrets_key`). The key is lazily created on first use with `PURPOSE_ENCRYPT | PURPOSE_DECRYPT`, `BLOCK_MODE_GCM`, `ENCRYPTION_PADDING_NONE`, 256-bit, and reused thereafter.

**`app/src/main/java/com/localdownloader/data/DownloadOptionSecretsStore.kt`**
- Constructor now takes a `SecretsCipher`.
- `writeSecrets()` serializes to JSON, encrypts via `secretsCipher.encrypt(...)`, and writes the encrypted bytes with the existing temp-file-then-rename pattern intact. If encryption fails it logs a warning and aborts the write rather than falling back to plaintext.
- `readSecrets()` reads the raw bytes and routes them through `decodeSecretsBytes()`.
- `decodeSecretsBytes()` (new) — if the blob carries the encryption magic byte, it decrypts; otherwise it transparently treats the bytes as a **legacy plaintext sidecar** and returns them as-is (logged as a migration notice). This means existing tasks written by the previous app version keep hydrating on upgrade, and the sidecar gets re-encrypted on the next `persist()` call. Fails closed (returns null) if an encrypted blob can't be decrypted.

**`app/src/main/java/com/localdownloader/di/RepositoryModule.kt`**
- Adds the Hilt `@Binds @Singleton` binding `KeystoreSecretsCipher -> SecretsCipher` so the injected interface resolves.

**`app/src/test/java/com/localdownloader/data/SecretsCipherFormatTest.kt` (new)**
- JVM unit tests (no Robolectric/Keystore needed) covering: magic-byte detection, plaintext-JSON rejection, too-short-input rejection, `formatBlob`/`extractIvAndCiphertext` round-trip, magic-byte placement, a full encrypt→decrypt round-trip through a fake cipher, and fail-closed behavior when plaintext is handed to `decrypt()`.

The existing `DownloadOptionSecretsStoreTest` (which exercises only the pure `containsPersistedSecrets` / `redactedForPersistence` / `applyPersistedSecrets` helpers) is unchanged and unaffected.

## Design notes

- **Why raw `javax.crypto` + Keystore instead of `androidx.security:security-crypto` (`EncryptedFile`/`MasterKey`)?** `EncryptedFile` wraps the exact same AES-GCM/Keystore primitives this PR uses directly, but it (a) is still an alpha-stage library with known ProGuard/minify friction — which the repo's `AI-agent/memory.md` explicitly calls out as a class of problem to avoid — and (b) owns its own file-writing path, which would have forced a rewrite of the existing atomic temp-file-then-rename write pattern the issue explicitly says is already correct. Using JCE directly gives full control of the on-disk format, keeps the atomic write untouched, needs no new dependency, and keeps the format logic pure-JVM-testable.
- **No ProGuard rule additions needed.** The new crypto uses only `javax.crypto.*` / `java.security.*` / `android.security.keystore.*` platform classes (kept by the Android Gradle plugin by default) and app-internal `internal` classes (covered by the existing `com.localdownloader.**` keep rules for serialization).
- **No new dependency** is added to `build.gradle.kts`; `minSdk = 26` satisfies the Keystore GCM requirements.

## Testing steps

1. `./gradlew test` — runs the new `SecretsCipherFormatTest` and the existing `DownloadOptionSecretsStoreTest`.
2. `./gradlew assembleStandardDebug` — confirms Hilt/KSP graph resolves the new `SecretsCipher` binding and the modified `DownloadOptionSecretsStore` constructor compiles.
3. `./gradlew lint` — code style/lint.
4. On-device smoke (optional): schedule a download that uses YouTube cookies/PO token, confirm the task still hydrates after a process restart, and inspect `noBackupFilesDir/task-option-secrets/<taskId>.json` to confirm it is no longer plaintext JSON.

## Remaining risks

- The Android Keystore key is per-device and never leaves the secure element / TEE, so secrets can't be decrypted off-device — by design. There is no backup/restore path for the encrypted sidecar; if a user migrates the app's data folder to a new device, the secrets sidecar won't decrypt and `hydrate()` will fall back to redacted options (the user re-enters credentials). This is the desired security behavior but worth noting.
- I could not run the Gradle build or unit tests in this environment (no JDK/Android SDK available in the sandbox); the code was verified by careful manual review against the existing patterns. CI will confirm compilation and tests.